### PR TITLE
MObject: implement missing functions and add tests

### DIFF
--- a/src/MObject.inl
+++ b/src/MObject.inl
@@ -15,6 +15,10 @@ py::class_<MObject>(m, "Object")
         return self.apiTypeStr();
     }, R"pbdoc(Return the type name of the internal Maya Object.)pbdoc")
 
+    .def("__eq__", [](MObject& self, const MObject& other) -> bool{
+        return (self == other);
+    }, R"pbdoc(Returns true if both MObjects refer to the same Maya object.)pbdoc")
+
     .def("__repr__", [](const MObject &a) {
         return "<cmdc.Object()>";
     }

--- a/src/MObject.inl
+++ b/src/MObject.inl
@@ -2,6 +2,8 @@ py::class_<MObject>(m, "Object")
     .def(py::init<>())
     .def(py::init<const MObject &>())
 
+    .def(py::self == MObject())
+
     .def("isNull", &MObject::isNull, 
         R"pbdoc(Return True if the internal Maya Object does not exist.)pbdoc")
     .def("hasFn", [](MObject& self, MFn::Type type) -> bool {
@@ -14,10 +16,6 @@ py::class_<MObject>(m, "Object")
     .def("apiTypeStr", [](MObject& self) -> std::string {
         return self.apiTypeStr();
     }, R"pbdoc(Return the type name of the internal Maya Object.)pbdoc")
-
-    .def("__eq__", [](MObject& self, const MObject& other) -> bool{
-        return (self == other);
-    }, R"pbdoc(Returns true if both MObjects refer to the same Maya object.)pbdoc")
 
     .def("__repr__", [](const MObject &self) {
         std::string ret = "<cmdc.Object(";

--- a/src/MObject.inl
+++ b/src/MObject.inl
@@ -19,7 +19,10 @@ py::class_<MObject>(m, "Object")
         return (self == other);
     }, R"pbdoc(Returns true if both MObjects refer to the same Maya object.)pbdoc")
 
-    .def("__repr__", [](const MObject &a) {
-        return "<cmdc.Object()>";
+    .def("__repr__", [](const MObject &self) {
+        std::string ret = "<cmdc.Object(";
+        ret += self.apiTypeStr();
+        ret += ")>";
+        return ret;
     }
 );

--- a/tests/test_MObject.py
+++ b/tests/test_MObject.py
@@ -1,0 +1,44 @@
+import cmdc
+
+def test_init_null():
+    obj = cmdc.Object()
+    assert obj.isNull()
+
+def test_init_mobject():
+    sel = cmdc.SelectionList().add("persp")
+    obj = sel.getDependNode(0)
+    other = cmdc.Object(obj)
+    assert not other.isNull()
+
+def test_hasFn():
+    sel = cmdc.SelectionList().add("persp")
+    obj = sel.getDependNode(0)
+    assert obj.hasFn(cmdc.Fn.kTransform)
+
+    sel = cmdc.SelectionList().add("perspShape")
+    obj = sel.getDependNode(0)
+    assert obj.hasFn(cmdc.Fn.kCamera)
+
+def test_apiType():
+    sel = cmdc.SelectionList().add("persp")
+    obj = sel.getDependNode(0)
+    assert obj.apiType() == cmdc.Fn.kTransform.value
+
+def test_apiTypeStr():
+    sel = cmdc.SelectionList().add("persp")
+    obj = sel.getDependNode(0)
+    assert obj.apiTypeStr() == cmdc.Fn.kTransform.name
+
+def test_equality():
+    sel = cmdc.SelectionList().add("persp")
+    obj = sel.getDependNode(0)
+    other = cmdc.Object(obj)
+    assert obj == other
+
+def test_inequality():
+    sel = cmdc.SelectionList()
+    sel.add("persp")
+    sel.add("front")
+    persp = sel.getDependNode(0)
+    front = sel.getDependNode(1)
+    assert persp != front


### PR DESCRIPTION
I have very little experience with C++ or writing bindings so I figured I would start small.
If the PR suits you, I'll start working on other classes.

I did the following:
- Implemented `MObject.__eq__`.
- Changed `MObject.__repr__` to include the apiTypeStr (wasn't 100% sure about the best way to format the string there).
- Added tests for all the `MObject` methods.
