### PR TITLE
implement MDagPath

### DIFF
--- a/src/MDagPath.inl
+++ b/src/MDagPath.inl
@@ -4,70 +4,48 @@ py::class_<MDagPath>(m, "DagPath")
     .def(py::self == MDagPath())
 
     .def("apiType", [](MDagPath & self) -> MFn::Type {
-        MStatus status = MStatus();
-        MFn::Type type = self.apiType(&status);
-
-        if (!status){
-            throw std::logic_error("(kFailure): Object does not exist");
+        if (!self.isValid()) {
+            throw std::logic_error("Call on invalid DagPath.");
         }
-
-        return type;
+        return self.apiType();
     }, R"pbdoc(Returns the type of the object at the end of the path.)pbdoc")
 
     .def("child", [](MDagPath & self, unsigned int i) -> MObject {
-        MStatus status = MStatus();
-        MObject child = self.child(i, &status);
-
-        switch (status.statusCode()){
-            case MS::kInvalidParameter:
-                throw std::out_of_range("(kInvalidParameter): Index not in valid range");
-            case MS::kFailure:
-                throw std::logic_error("(kFailure): Object does not exist");
+        if (!self.isValid()) {
+            throw std::logic_error("Call on invalid DagPath.");
+        } else if (i >= self.childCount()) {
+                throw std::out_of_range("Index not in valid range");
         }
 
-        return child;
+        return self.child(i);
     }, R"pbdoc(Returns the specified child of the object at the end of the path.)pbdoc")
 
     .def("childCount", [](MDagPath & self) -> int {
-        MStatus status = MStatus();
-        int childCount = self.childCount(&status);
-
-        if (!status) {
-            throw std::logic_error("(kFailure): Object does not exist");
+        if (!self.isValid()) {
+            throw std::logic_error("Call on invalid DagPath.");
         }
-
-        return childCount;
+        return self.childCount();
     }, R"pbdoc(Returns the number of objects parented directly beneath the object at the end of the path.)pbdoc")
 
     .def("exclusiveMatrix", [](MDagPath & self) -> MMatrix {
-        MStatus status = MStatus();
-        MMatrix exclusive_matrix = self.exclusiveMatrix(&status);
-
-        if (!status) {
-            throw std::logic_error("(kFailure): Object does not exist");
+        if (!self.isValid()) {
+            throw std::logic_error("Call on invalid DagPath.");
         }
-
-        return exclusive_matrix;
+        return self.exclusiveMatrix();
     }, R"pbdoc(Returns the matrix for all transforms in the path, excluding the end object.)pbdoc")
 
     .def("exclusiveMatrixInverse", [](MDagPath & self) -> MMatrix {
-        MStatus status = MStatus();
-        MMatrix exclusive_matrix_inverse = self.exclusiveMatrixInverse(&status);
-
-        if (!status) {
-            throw std::logic_error("(kFailure): Object does not exist");
+        if (!self.isValid()) {
+            throw std::logic_error("Call on invalid DagPath.");
         }
-
-        return exclusive_matrix_inverse;
+        return self.exclusiveMatrixInverse();
     }, R"pbdoc(Returns the inverse of exclusiveMatrix().)pbdoc")
 
     .def("extendToShape", [](MDagPath & self) {
-        MStatus status = self.extendToShape();
-
-        if (!status) {
-            throw std::logic_error("(kFailure): Object does not exist");
+        if (!self.isValid()) {
+            throw std::logic_error("Call on invalid DagPath.");
         }
-
+        self.extendToShape();
     }, R"pbdoc(Extends the path to the specified shape node parented directly beneath the transform at the current end of the path.)pbdoc")
 
     .def("fullPathName", [](MDagPath & self) -> MString {
@@ -123,7 +101,7 @@ py::class_<MDagPath>(m, "DagPath")
     }, R"pbdoc(Returns true if the DAG Node at the end of the path is templated.)pbdoc")
 
     .def("isValid", [](MDagPath & self) -> bool {
-        throw std::logic_error{"Function not yet implemented."};
+        return self.isValid();
     }, R"pbdoc(Returns True if this is a valid path.)pbdoc")
 
     .def("isVisible", [](MDagPath & self) -> bool {

--- a/src/MDagPath.inl
+++ b/src/MDagPath.inl
@@ -79,7 +79,29 @@ py::class_<MDagPath>(m, "DagPath")
         if (!status) {
             throw std::logic_error(status.errorString().asChar());
         }
-    }, R"pbdoc(Extends the path to the specified shape node parented directly beneath the transform at the current end of the path.)pbdoc")
+    }, R"pbdoc(If the object at the end of this path is a transform and there is a shape node directly beneath it in the hierarchy, then the path is extended to that geometry node.
+
+NOTE: This method will fail if there multiple shapes below the transform.)pbdoc")
+
+    .def("extendToShapeDirectlyBelow", [](MDagPath & self, unsigned int index) {
+        if (!self.isValid()) {
+            throw std::logic_error("Call on invalid DagPath.");
+        } 
+
+        unsigned int number_of_shapes;
+        self.numberOfShapesDirectlyBelow(number_of_shapes);
+        if (index >= number_of_shapes) {
+            throw std::out_of_range("Index out of range.");
+        }
+
+        MStatus status = self.extendToShapeDirectlyBelow(index);
+
+        if (!status) {
+            throw std::logic_error(status.errorString().asChar());
+        }
+    }, R"pbdoc(This method is used if the end of the path is a transform and there are shapes directly below the transform.
+The shape to extend to is set by passing in an appropriate index parameter.
+Use the `numberOfShapesDirectlyBelow()` method to determine how many shapes are below)pbdoc")
 
     .def("fullPathName", [](MDagPath & self) -> std::string {
         if (!self.isValid()) {
@@ -336,9 +358,24 @@ py::class_<MDagPath>(m, "DagPath")
     }, R"pbdoc(Extends the path to the specified child object, which must be parented directly beneath the object currently at the end of the path.)pbdoc")
 
     .def("set", [](MDagPath & self, MDagPath src) {
-        throw std::logic_error{"Function not yet implemented."};
+        MStatus status = self.set(src);
+
+        if (!status) {
+            throw std::logic_error(status.errorString().asChar());
+        }
     }, R"pbdoc(Replaces the current path held by this object with another.)pbdoc")
 
     .def("transform", [](MDagPath & self) -> MObject {
-        throw std::logic_error{"Function not yet implemented."};
+        if (!self.isValid()) {
+            throw std::logic_error("Call on invalid DagPath.");
+        }
+
+        MStatus status;
+        MObject result = self.transform();
+
+        if (!status) {
+            throw std::logic_error(status.errorString().asChar());
+        }
+
+        return result;
     }, R"pbdoc(Returns the last transform node on the path.)pbdoc");

--- a/src/MDagPath.inl
+++ b/src/MDagPath.inl
@@ -138,13 +138,13 @@ Use the `numberOfShapesDirectlyBelow()` method to determine how many shapes are 
         return path;
     }, R"pbdoc(Returns the first path found to the given node.)pbdoc")
 
-    .def_static("getAllPathsTo", [](MObject node) -> std::vector<MDagPath> {
+    .def_static("getAllPathsBelow", [](MObject node) -> std::vector<MDagPath> {
         throw std::logic_error{"Function not yet implemented."};
     }, R"pbdoc(Returns all paths to the given node.)pbdoc")
 
-    .def("getDisplayStatus", [](MDagPath & self) -> int {
+    .def_static("getAllPathsTo", [](MObject node) -> std::vector<MDagPath> {
         throw std::logic_error{"Function not yet implemented."};
-    }, R"pbdoc(Returns the display status for this path.)pbdoc")
+    }, R"pbdoc(Returns all paths to the given node.)pbdoc")
 
     .def("getDrawOverrideInfo", [](MDagPath & self) -> MDAGDrawOverrideInfo {
         throw std::logic_error{"Function not yet implemented."};
@@ -278,6 +278,10 @@ Use the `numberOfShapesDirectlyBelow()` method to determine how many shapes are 
 
         return result;
     }, R"pbdoc(Returns the number of nodes on the path, not including the DAG's root node.)pbdoc")
+
+    .def("matchTransform", [](MDagPath & self) {
+        throw std::logic_error{"Function not yet implemented."};
+    }, R"pbdoc(Extends the path to the specified shape node parented directly beneath the transform at the current end of the path.)pbdoc")
 
     .def("node", [](MDagPath & self) -> MObject {
         if (!self.isValid()) {

--- a/src/MDagPath.inl
+++ b/src/MDagPath.inl
@@ -133,27 +133,87 @@ py::class_<MDagPath>(m, "DagPath")
     }, R"pbdoc(Returns the specified sub-path of this path.)pbdoc")
 
     .def("hasFn", [](MDagPath & self, MFn::Type type) -> bool {
-        return self.hasFn(type);
+        if (!self.isValid()) {
+            throw std::logic_error("Call on invalid DagPath.");
+        }
+
+        MStatus status;
+        bool result = self.hasFn(type, &status);
+
+        if (!status) {
+            throw std::logic_error(status.errorString().asChar());
+        }
+
+        return result;
     }, R"pbdoc(Returns True if the object at the end of the path supports the given function set.)pbdoc")
 
     .def("inclusiveMatrix", [](MDagPath & self) -> MMatrix {
-        throw std::logic_error{"Function not yet implemented."};
+        if (!self.isValid()) {
+            throw std::logic_error("Call on invalid DagPath.");
+        }
+        return self.inclusiveMatrix();
     }, R"pbdoc(Returns the matrix for all transforms in the path, including the end object, if it is a transform.)pbdoc")
 
     .def("inclusiveMatrixInverse", [](MDagPath & self) -> MMatrix {
-        throw std::logic_error{"Function not yet implemented."};
+        if (!self.isValid()) {
+            throw std::logic_error("Call on invalid DagPath.");
+        }
+
+        MStatus status;
+        MMatrix result = self.inclusiveMatrixInverse(&status);
+
+        if (!status) {
+            throw std::logic_error(status.errorString().asChar());
+        }
+
+        return result;
     }, R"pbdoc(Returns the inverse of inclusiveMatrix().)pbdoc")
 
     .def("instanceNumber", [](MDagPath & self) -> int {
-        throw std::logic_error{"Function not yet implemented."};
+        if (!self.isValid()) {
+            throw std::logic_error("Call on invalid DagPath.");
+        } else if (!self.isInstanced()) {
+            throw pybind11::type_error("Call on a non instanced DagPath.");
+        }
+
+        MStatus status;
+        int result = self.instanceNumber(&status);
+
+        if (!status) {
+            throw std::logic_error(status.errorString().asChar());
+        }
+
+        return result;
     }, R"pbdoc(Returns the instance number of this path to the object at the end.)pbdoc")
 
     .def("isInstanced", [](MDagPath & self) -> bool {
-        throw std::logic_error{"Function not yet implemented."};
+        if (!self.isValid()) {
+            throw std::logic_error("Call on invalid DagPath.");
+        }
+
+        MStatus status;
+        bool result = self.isInstanced(&status);
+
+        if (!status) {
+            throw std::logic_error(status.errorString().asChar());
+        }
+
+        return result;
     }, R"pbdoc(Returns True if the object at the end of the path can be reached by more than one path.)pbdoc")
 
     .def("isTemplated", [](MDagPath & self) -> bool {
-        throw std::logic_error{"Function not yet implemented."};
+        if (!self.isValid()) {
+            throw std::logic_error("Call on invalid DagPath.");
+        }
+
+        MStatus status;
+        bool result = self.isTemplated(&status);
+
+        if (!status) {
+            throw std::logic_error(status.errorString().asChar());
+        }
+
+        return result;
     }, R"pbdoc(Returns true if the DAG Node at the end of the path is templated.)pbdoc")
 
     .def("isValid", [](MDagPath & self) -> bool {
@@ -168,23 +228,79 @@ py::class_<MDagPath>(m, "DagPath")
     }, R"pbdoc(Returns True if this is a valid path.)pbdoc")
 
     .def("isVisible", [](MDagPath & self) -> bool {
-        throw std::logic_error{"Function not yet implemented."};
+        if (!self.isValid()) {
+            throw std::logic_error("Call on invalid DagPath.");
+        }
+
+        MStatus status;
+        bool result = self.isVisible(&status);
+
+        if (!status) {
+            throw std::logic_error(status.errorString().asChar());
+        }
+
+        return result;
     }, R"pbdoc(Returns true if the DAG Node at the end of the path is visible.)pbdoc")
 
     .def("length", [](MDagPath & self) -> int {
-        throw std::logic_error{"Function not yet implemented."};
+        if (!self.isValid()) {
+            throw std::logic_error("Call on invalid DagPath.");
+        }
+
+        MStatus status;
+        int result = self.length(&status);
+
+        if (!status) {
+            throw std::logic_error(status.errorString().asChar());
+        }
+
+        return result;
     }, R"pbdoc(Returns the number of nodes on the path, not including the DAG's root node.)pbdoc")
 
     .def("node", [](MDagPath & self) -> MObject {
-        throw std::logic_error{"Function not yet implemented."};
+        if (!self.isValid()) {
+            throw std::logic_error("Call on invalid DagPath.");
+        }
+
+        MStatus status;
+        MObject result = self.node(&status);
+
+        if (!status) {
+            throw std::logic_error(status.errorString().asChar());
+        }
+
+        return result;
     }, R"pbdoc(Returns the DAG node at the end of the path.)pbdoc")
 
     .def("numberOfShapesDirectlyBelow", [](MDagPath & self) -> unsigned int {
-        throw std::logic_error{"Function not yet implemented."};
+        if (!self.isValid()) {
+            throw std::logic_error("Call on invalid DagPath.");
+        }
+
+        unsigned int result;
+
+        MStatus status = self.numberOfShapesDirectlyBelow(result);
+
+        if (!status) {
+            throw std::logic_error(status.errorString().asChar());
+        }
+
+        return result;
     }, R"pbdoc(Returns the number of shape nodes parented directly beneath the transform at the end of the path.)pbdoc")
 
-    .def("partialPathName", [](MDagPath & self) -> MString {
-        throw std::logic_error{"Function not yet implemented."};
+    .def("partialPathName", [](MDagPath & self) -> std::string {
+        if (!self.isValid()) {
+            throw std::logic_error("Call on invalid DagPath.");
+        }
+
+        MStatus status;
+        MString result = self.partialPathName(&status);
+
+        if (!status) {
+            throw std::logic_error(status.errorString().asChar());
+        }
+
+        return std::string(result.asChar());
     }, R"pbdoc(Returns the minimum string representation which will uniquely identify the path.)pbdoc")
 
     .def("pathCount", [](MDagPath & self) -> int {
@@ -192,11 +308,31 @@ py::class_<MDagPath>(m, "DagPath")
     }, R"pbdoc(Returns the number of sub-paths which make up this path.)pbdoc")
 
     .def("pop", [](MDagPath & self, unsigned int num = 1) {
-        throw std::logic_error{"Function not yet implemented."};
-    }, R"pbdoc(Removes objects from the end of the path.)pbdoc")
+        if (!self.isValid()) {
+            throw std::logic_error("Call on invalid DagPath.");
+        } else if (num > self.length()) {
+            throw pybind11::value_error("");
+        }
+
+        MStatus status = self.pop(num);
+
+        if (!status) {
+            throw std::logic_error(status.errorString().asChar());
+        }
+
+    }, R"pbdoc(Removes objects from the end of the path.)pbdoc", py::arg("num") = 1)
 
     .def("push", [](MDagPath & self, MObject child) {
-        throw std::logic_error{"Function not yet implemented."};
+        if (!self.isValid()) {
+            throw std::logic_error("Call on invalid DagPath.");
+        }
+
+        MStatus status = self.push(child);
+
+        if (!status) {
+            throw std::logic_error(status.errorString().asChar());
+        }
+
     }, R"pbdoc(Extends the path to the specified child object, which must be parented directly beneath the object currently at the end of the path.)pbdoc")
 
     .def("set", [](MDagPath & self, MDagPath src) {

--- a/src/MDagPath.inl
+++ b/src/MDagPath.inl
@@ -48,16 +48,26 @@ py::class_<MDagPath>(m, "DagPath")
         self.extendToShape();
     }, R"pbdoc(Extends the path to the specified shape node parented directly beneath the transform at the current end of the path.)pbdoc")
 
-    .def("fullPathName", [](MDagPath & self) -> MString {
-        throw std::logic_error{"Function not yet implemented."};
+    .def("fullPathName", [](MDagPath & self) -> std::string {
+        if (!self.isValid()) {
+            throw std::logic_error("Call on invalid Dag Path.");
+        }
+        return std::string(self.fullPathName().asChar());
     }, R"pbdoc(Returns a string representation of the path from the DAG root to the path's last node.)pbdoc")
 
     .def_static("getAPathTo", [](MObject node) -> MDagPath {
-        throw std::logic_error{"Function not yet implemented."};
-    }, R"pbdoc(Returns the first path found to the given node.)pbdoc")
+        if (node.isNull()) {
+            throw std::logic_error("Passed Object is null.");
+        } else if (!node.hasFn(MFn::Type::kDagNode)) {
+            std::string error_msg = "Passed Object has Fn ";
+            error_msg += node.apiTypeStr();
+            error_msg += ". Should be kDagNode or subclass.";
+            throw pybind11::type_error(error_msg);
+        }
 
-    .def_static("getAPathTo", [](MObject node) -> MDagPath {
-        throw std::logic_error{"Function not yet implemented."};
+        MDagPath path = MDagPath();
+        MDagPath::getAPathTo(node, path);
+        return path;
     }, R"pbdoc(Returns the first path found to the given node.)pbdoc")
 
     .def_static("getAllPathsTo", [](MObject node) -> std::vector<MDagPath> {

--- a/src/MDagPath.inl
+++ b/src/MDagPath.inl
@@ -1,28 +1,73 @@
 py::class_<MDagPath>(m, "DagPath")
     .def(py::init<>())
 
+    .def(py::self == MDagPath())
+
     .def("apiType", [](MDagPath & self) -> MFn::Type {
-        throw std::logic_error{"Function not yet implemented."};
+        MStatus status = MStatus();
+        MFn::Type type = self.apiType(&status);
+
+        if (!status){
+            throw std::logic_error("(kFailure): Object does not exist");
+        }
+
+        return type;
     }, R"pbdoc(Returns the type of the object at the end of the path.)pbdoc")
 
     .def("child", [](MDagPath & self, unsigned int i) -> MObject {
-        throw std::logic_error{"Function not yet implemented."};
+        MStatus status = MStatus();
+        MObject child = self.child(i, &status);
+
+        switch (status.statusCode()){
+            case MS::kInvalidParameter:
+                throw std::out_of_range("(kInvalidParameter): Index not in valid range");
+            case MS::kFailure:
+                throw std::logic_error("(kFailure): Object does not exist");
+        }
+
+        return child;
     }, R"pbdoc(Returns the specified child of the object at the end of the path.)pbdoc")
 
     .def("childCount", [](MDagPath & self) -> int {
-        throw std::logic_error{"Function not yet implemented."};
+        MStatus status = MStatus();
+        int childCount = self.childCount(&status);
+
+        if (!status) {
+            throw std::logic_error("(kFailure): Object does not exist");
+        }
+
+        return childCount;
     }, R"pbdoc(Returns the number of objects parented directly beneath the object at the end of the path.)pbdoc")
 
     .def("exclusiveMatrix", [](MDagPath & self) -> MMatrix {
-        throw std::logic_error{"Function not yet implemented."};
+        MStatus status = MStatus();
+        MMatrix exclusive_matrix = self.exclusiveMatrix(&status);
+
+        if (!status) {
+            throw std::logic_error("(kFailure): Object does not exist");
+        }
+
+        return exclusive_matrix;
     }, R"pbdoc(Returns the matrix for all transforms in the path, excluding the end object.)pbdoc")
 
     .def("exclusiveMatrixInverse", [](MDagPath & self) -> MMatrix {
-        throw std::logic_error{"Function not yet implemented."};
+        MStatus status = MStatus();
+        MMatrix exclusive_matrix_inverse = self.exclusiveMatrixInverse(&status);
+
+        if (!status) {
+            throw std::logic_error("(kFailure): Object does not exist");
+        }
+
+        return exclusive_matrix_inverse;
     }, R"pbdoc(Returns the inverse of exclusiveMatrix().)pbdoc")
 
     .def("extendToShape", [](MDagPath & self) {
-        throw std::logic_error{"Function not yet implemented."};
+        MStatus status = self.extendToShape();
+
+        if (!status) {
+            throw std::logic_error("(kFailure): Object does not exist");
+        }
+
     }, R"pbdoc(Extends the path to the specified shape node parented directly beneath the transform at the current end of the path.)pbdoc")
 
     .def("fullPathName", [](MDagPath & self) -> MString {

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,9 +1,13 @@
 import atexit
 
 import maya.standalone 
+from maya import cmds
 
 def setup():
     maya.standalone.initialize()
+
+def new_scene():
+    cmds.file(new=True, force=True)
 
 def teardown():
     maya.standalone.uninitialize()

--- a/tests/test_MDagPath.py
+++ b/tests/test_MDagPath.py
@@ -96,6 +96,45 @@ def test_extendToShape():
         invalid_dag.extendToShape,
     )
 
+def test_fullPathName():
+    sel = cmdc.SelectionList().add("persp").add("perspShape")
+
+    persp = sel.getDagPath(0)
+    persp_path_name =persp.fullPathName() 
+    assert persp_path_name == "|persp"
+    assert isinstance(persp_path_name, str)
+
+    persp_shape = sel.getDagPath(1)
+    assert persp_shape.fullPathName() == "|persp|perspShape"
+
+    invalid_dag = cmdc.DagPath()
+    nose.tools.assert_raises(
+        RuntimeError,
+        invalid_dag.fullPathName,
+    )
+
+def test_getAPathTo():
+    sel = cmdc.SelectionList().add("persp").add("time1")
+
+    persp_obj = sel.getDependNode(0)
+    persp_dag = sel.getDagPath(0)
+    result = cmdc.DagPath.getAPathTo(persp_obj) 
+    assert result == persp_dag
+
+    time_obj = sel.getDependNode(1)
+    nose.tools.assert_raises(
+        TypeError,
+        cmdc.DagPath.getAPathTo,
+        time_obj
+    )
+
+    invalid_obj = cmdc.Object()
+    nose.tools.assert_raises(
+        RuntimeError,
+        cmdc.DagPath.getAPathTo,
+        invalid_obj 
+    )
+
 
 def test_isValid():
     sel = cmdc.SelectionList().add("persp")

--- a/tests/test_MDagPath.py
+++ b/tests/test_MDagPath.py
@@ -13,13 +13,10 @@ def test_apiType():
     sel = cmdc.SelectionList().add("persp")
 
     valid_dag = sel.getDagPath(0)
-    assert valid_dag.apiType() == cmdc.Fn.Type.kTransform
+    assert valid_dag.apiType() == cmdc.Fn.kTransform
 
     invalid_dag = cmdc.DagPath()
-    nose.tools.assert_raises(
-        RuntimeError,
-        invalid_dag.apiType,
-    )
+    assert invalid_dag.apiType() == cmdc.Fn.kInvalid
 
 def test_child():
     sel = cmdc.SelectionList().add("persp").add("perspShape")

--- a/tests/test_MDagPath.py
+++ b/tests/test_MDagPath.py
@@ -62,7 +62,6 @@ def test_exclusiveMatrix():
     persp = sel.getDagPath(0)
     assert isinstance(persp.exclusiveMatrix(), cmdc.Matrix)
 
-    # I would have expected this to raise a RuntimeError
     invalid_dag = cmdc.DagPath()
     nose.tools.assert_raises(
         RuntimeError,
@@ -76,7 +75,6 @@ def test_exclusiveMatrixInverse():
     persp = sel.getDagPath(0)
     assert isinstance(persp.exclusiveMatrixInverse(), cmdc.Matrix)
 
-    # I would have expected this to raise a RuntimeError
     invalid_dag = cmdc.DagPath()
     nose.tools.assert_raises(
         RuntimeError,
@@ -97,3 +95,13 @@ def test_extendToShape():
         RuntimeError,
         invalid_dag.extendToShape,
     )
+
+
+def test_isValid():
+    sel = cmdc.SelectionList().add("persp")
+    persp = sel.getDagPath(0)
+    assert persp.isValid()
+
+    invalid_dag = cmdc.DagPath()
+    assert not invalid_dag.isValid()
+

--- a/tests/test_MDagPath.py
+++ b/tests/test_MDagPath.py
@@ -1,0 +1,99 @@
+import nose
+import cmdc
+
+def test_equality():
+    sel = cmdc.SelectionList().add("persp")
+
+    a = sel.getDagPath(0)
+    b = sel.getDagPath(0)
+    assert a == b
+
+
+def test_apiType():
+    sel = cmdc.SelectionList().add("persp")
+
+    valid_dag = sel.getDagPath(0)
+    assert valid_dag.apiType() == cmdc.Fn.Type.kTransform
+
+    invalid_dag = cmdc.DagPath()
+    nose.tools.assert_raises(
+        RuntimeError,
+        invalid_dag.apiType,
+    )
+
+def test_child():
+    sel = cmdc.SelectionList().add("persp").add("perspShape")
+
+    dag_with_child = sel.getDagPath(0)
+    assert isinstance(dag_with_child.child(0), cmdc.Object)
+    
+    dag_without_children = sel.getDagPath(1)
+    nose.tools.assert_raises(
+        IndexError,
+        dag_without_children.child,
+        0
+    )
+
+    invalid_dag = cmdc.DagPath()
+    nose.tools.assert_raises(
+        RuntimeError,
+        invalid_dag.child,
+        0
+    )
+
+def test_childCount():
+    sel = cmdc.SelectionList().add("persp").add("perspShape")
+
+    persp = sel.getDagPath(0)
+    assert persp.childCount() == 1
+
+    persp_shape = sel.getDagPath(1)
+    assert persp_shape.childCount() == 0
+
+    invalid_dag = cmdc.DagPath()
+    nose.tools.assert_raises(
+        RuntimeError,
+        invalid_dag.childCount,
+    )
+
+def test_exclusiveMatrix():
+    sel = cmdc.SelectionList().add("persp").add("perspShape")
+
+    persp = sel.getDagPath(0)
+    assert isinstance(persp.exclusiveMatrix(), cmdc.Matrix)
+
+    # I would have expected this to raise a RuntimeError
+    invalid_dag = cmdc.DagPath()
+    nose.tools.assert_raises(
+        RuntimeError,
+        invalid_dag.exclusiveMatrix,
+    )
+
+
+def test_exclusiveMatrixInverse():
+    sel = cmdc.SelectionList().add("persp").add("perspShape")
+
+    persp = sel.getDagPath(0)
+    assert isinstance(persp.exclusiveMatrixInverse(), cmdc.Matrix)
+
+    # I would have expected this to raise a RuntimeError
+    invalid_dag = cmdc.DagPath()
+    nose.tools.assert_raises(
+        RuntimeError,
+        invalid_dag.exclusiveMatrixInverse,
+    )
+
+
+def test_extendToShape():
+    sel = cmdc.SelectionList().add("persp").add("perspShape")
+
+    persp = sel.getDagPath(0)
+    persp_shape = sel.getDagPath(1)
+    persp.extendToShape()
+    assert persp == persp_shape
+
+    invalid_dag = cmdc.DagPath()
+    nose.tools.assert_raises(
+        RuntimeError,
+        invalid_dag.extendToShape,
+    )


### PR DESCRIPTION
This is not ready to be merged yet. I'm making the PR for visibility, and because I had a few questions.

My questions:
1. Are we aiming to be more consistent with the C++ API or OpenMaya2?
`DagPath.extendToShape()` returns a reference to self in OM2 but not in the C++ API.
I feel like not returning anything would make more sense since `self` is already modified by the method
2. Do we have a standardized format for the error messages?
I've just copied OM2's messages so far.
3. I was expecting `exclusiveMatrix` and `exclusiveMatrixInverse` to fail when called from an invalid DagPath but they return an identity matrix instead.
This seems consistent with OM2 but I'm not sure why they're not raising a RuntimeError where something like `childCount` does with a similar implementation