### PR TITLE
Implement most of MPlug

### DIFF
--- a/src/MPlug.inl
+++ b/src/MPlug.inl
@@ -12,13 +12,7 @@ plug.def(py::init<>())
 
     .def("array", [](MPlug & self) -> MPlug {
         plug::assert_not_null(self);
-
-        if (!self.isElement()) {
-            MString error_msg("Plug '^1s' is not an array element.");
-                    error_msg.format(error_msg, self.name());
-
-            throw pybind11::type_error(error_msg.asChar());
-        }
+        plug::assert_is_element(self);
 
         MStatus status;
         MPlug result = self.array(&status);
@@ -89,13 +83,8 @@ plug.def(py::init<>())
 
     .def("child", [](MPlug & self, MObject attr) -> MPlug {
         plug::assert_not_null(self);
-
-        if ((self.isCompound() && self.isArray()) || !self.isCompound()) {
-            MString error_msg("Plug '^1s' is not a compound plug or is a compound array plug.");
-                    error_msg.format(error_msg, self.name());
-
-            throw pybind11::type_error(error_msg.asChar());
-        }
+        plug::assert_is_compound(self);
+        plug::assert_is_not_array(self);
 
         MStatus status;
         MPlug result;
@@ -131,13 +120,8 @@ plug.def(py::init<>())
 
     .def("child", [](MPlug & self, unsigned int index) -> MPlug {
         plug::assert_not_null(self);
-
-        if ((self.isCompound() && self.isArray()) || !self.isCompound()) {
-            MString error_msg("Plug '^1s' is not a compound plug or is a compound array plug.");
-                    error_msg.format(error_msg, self.name());
-
-            throw pybind11::type_error(error_msg.asChar());
-        }
+        plug::assert_is_compound(self);
+        plug::assert_is_not_array(self);
 
         if (index >= self.numChildren()) {
             MString error_msg("Plug '^1s' only has '^2s' children.");
@@ -211,14 +195,8 @@ Note that the behavior of connectedTo() is identical to destinationsWithConversi
 
     .def("elementByLogicalIndex", [](MPlug & self, unsigned int index) -> MPlug {
         plug::assert_not_null(self);
-
-        if (!self.isArray()) {
-            MString error_msg("Plug '^1s' is not an array plug.");
-                    error_msg.format(error_msg, self.name());
-
-            throw pybind11::type_error(error_msg.asChar());
-        }
-
+        plug::assert_is_array(self);
+        
         MStatus status;
         MPlug result = self.elementByLogicalIndex(index, &status);
         
@@ -229,13 +207,7 @@ Note that the behavior of connectedTo() is identical to destinationsWithConversi
 
     .def("elementByPhysicalIndex", [](MPlug & self, unsigned int index) -> MPlug {
         plug::assert_not_null(self);
-
-        if (!self.isArray()) {
-            MString error_msg("Plug '^1s' is not an array plug.");
-                    error_msg.format(error_msg, self.name());
-
-            throw pybind11::type_error(error_msg.asChar());
-        }
+        plug::assert_is_array(self);
 
         if (index >= self.numElements()) {
             MString error_msg("Plug '^1s' only has '^2s' elements.");
@@ -254,13 +226,7 @@ Note that the behavior of connectedTo() is identical to destinationsWithConversi
 
     .def("evaluateNumElements", [](MPlug & self) -> unsigned int {
         plug::assert_not_null(self);
-
-        if (!self.isArray()) {
-            MString error_msg("Plug '^1s' is not an array plug.");
-                    error_msg.format(error_msg, self.name());
-
-            throw pybind11::type_error(error_msg.asChar());
-        }
+        plug::assert_is_array(self);
 
         MStatus status;
         unsigned int result = self.evaluateNumElements(&status);
@@ -272,13 +238,7 @@ Note that the behavior of connectedTo() is identical to destinationsWithConversi
 
     .def("getExistingArrayAttributeIndices", [](MPlug & self) -> std::vector<int> {
         plug::assert_not_null(self);
-
-        if (!self.isArray()) {
-            MString error_msg("Plug '^1s' is not an array plug.");
-                    error_msg.format(error_msg, self.name());
-
-            throw pybind11::type_error(error_msg.asChar());
-        }
+        plug::assert_is_array(self);
 
         MStatus status;
         MIntArray results;
@@ -370,13 +330,7 @@ Note that the behavior of connectedTo() is identical to destinationsWithConversi
 
     .def("logicalIndex", [](MPlug & self) -> unsigned int {
         plug::assert_not_null(self);
-
-        if (!self.isElement()) {
-            MString error_msg("Plug '^1s' is not an array element plug.");
-                    error_msg.format(error_msg, self.name());
-
-            throw pybind11::type_error(error_msg.asChar());
-        }
+        plug::assert_is_element(self);
 
         MStatus status;
         unsigned int result = self.logicalIndex(&status);
@@ -403,13 +357,7 @@ Note that the behavior of connectedTo() is identical to destinationsWithConversi
 
     .def("numChildren", [](MPlug & self) -> unsigned int {
         plug::assert_not_null(self);
-
-        if (!self.isCompound()) {
-            MString error_msg("Plug '^1s' is not a compound plug.");
-                    error_msg.format(error_msg, self.name());
-
-            throw pybind11::type_error(error_msg.asChar());
-        }
+        plug::assert_is_compound(self);
 
         MStatus status;
         unsigned int result = self.numChildren(&status);
@@ -429,13 +377,7 @@ Note that the behavior of connectedTo() is identical to destinationsWithConversi
 
     .def("numElements", [](MPlug & self) -> unsigned int {
         plug::assert_not_null(self);
-
-        if (!self.isArray()) {
-            MString error_msg("Plug '^1s' is not an array plug.");
-                    error_msg.format(error_msg, self.name());
-
-            throw pybind11::type_error(error_msg.asChar());
-        }
+        plug::assert_is_array(self);
 
         MStatus status;
         unsigned int result = self.numElements(&status);

--- a/src/MPlug.inl
+++ b/src/MPlug.inl
@@ -291,8 +291,26 @@ Note that the behavior of connectedTo() is identical to destinationsWithConversi
         return self.isSource();
     }, R"pbdoc(True if plug is the source of a connection.)pbdoc")
 
-    .def("logicalIndex", [](MPlug & self) -> int {
-        throw std::logic_error{"Function not yet implemented."};
+    .def("logicalIndex", [](MPlug & self) -> unsigned int {
+       if (self.isNull()) {
+            throw std::invalid_argument("Accessed a null plug.");
+        }
+
+        if (!self.isElement()) {
+            MString error_msg("Plug '^1s' is not an array element plug.");
+                    error_msg.format(error_msg, self.name());
+
+            throw pybind11::type_error(error_msg.asChar());
+        }
+
+        MStatus status;
+        unsigned int result = self.logicalIndex(&status);
+
+        if (!status) {
+            throw std::runtime_error(status.errorString().asChar());
+        }
+
+        return result; 
     }, R"pbdoc(Returns this plug's logical index within its parent array.)pbdoc")
 
     .def("name", [](MPlug & self) -> std::string {

--- a/src/MPlug.inl
+++ b/src/MPlug.inl
@@ -182,13 +182,26 @@ plug.def(py::init<>())
         throw std::logic_error{"Function not yet implemented."};
     }, R"pbdoc(Constructs a data handle for the plug.)pbdoc")
 
-    .def("destinations", [](MPlug & self, std::vector<MPlug> theDestinations) -> bool {
-        throw std::logic_error{"Function not yet implemented."};
+    .def("destinations", [](MPlug & self) -> std::vector<MPlug> {
+        if (self.isNull()) {
+            throw std::invalid_argument("Accessed a null plug.");
+        }
+        
+        MPlugArray results;
+        MStatus status;
+
+        self.destinations(results, &status);
+
+        if (!status) {
+            throw std::runtime_error(status.errorString().asChar());
+        }
+
+        return atov::convert(results);  
     }, R"pbdoc(If this plug is a source, return the destination plugs connected to it.
 If this plug is not a source, a null plug is returned.
 This method will produce the networked version of the connected plug.)pbdoc")
 
-    .def("destinationsWithConversions", [](MPlug & self, std::vector<MPlug> theDestinations) -> bool {
+    .def("destinationsWithConversions", [](MPlug & self) -> std::vector<MPlug> {
         throw std::logic_error{"Function not yet implemented."};
     }, R"pbdoc(If this plug is a source, return the destination plugs connected to it.
 This method is very similar to the destinations() method.  The only difference is that the destinations() method skips over any unit conversion node connected to this source, and returns the destination of the unit conversion node.

--- a/src/MPlug.inl
+++ b/src/MPlug.inl
@@ -23,9 +23,7 @@ plug.def(py::init<>())
         MStatus status;
         MPlug result = self.array(&status);
 
-        if (!status) {
-            throw std::runtime_error(status.errorString().asChar());
-        }
+        CHECK_STATUS(status)
 
         return result;
     }, R"pbdoc(Returns a plug for the array of plugs of which this plug is an element.)pbdoc")
@@ -84,9 +82,7 @@ plug.def(py::init<>())
         MStatus status;
         MObject result = self.attribute(&status);
 
-        if (!status) {
-            throw std::runtime_error(status.errorString().asChar());
-        }
+        CHECK_STATUS(status)
 
         return result;    
     }, R"pbdoc(Returns the attribute currently referenced by this plug.)pbdoc")
@@ -128,9 +124,7 @@ plug.def(py::init<>())
             throw std::invalid_argument(error_msg.asChar());
         }
 
-        if (!status) {
-            throw std::runtime_error(status.errorString().asChar());
-        }
+        CHECK_STATUS(status)
 
         return result;
     }, R"pbdoc(Returns a plug for the specified child attribute of this plug.)pbdoc")
@@ -155,9 +149,7 @@ plug.def(py::init<>())
         MStatus status;
         MPlug result = self.child(index, &status);
 
-        if (!status) {
-            throw std::runtime_error(status.errorString().asChar());
-        }
+        CHECK_STATUS(status)
 
         return result;    
     }, R"pbdoc(Returns a plug for the specified child attribute of this plug.)pbdoc")
@@ -169,9 +161,7 @@ plug.def(py::init<>())
         MPlugArray results;
         self.connectedTo(results, asDst, asSrc, &status);
 
-        if (!status) {
-            throw std::runtime_error(status.errorString().asChar());
-        }
+        CHECK_STATUS(status)
 
         return atov::convert(results);   
     }, R"pbdoc(Returns an array of plugs which are connected to this one.)pbdoc")
@@ -192,9 +182,7 @@ plug.def(py::init<>())
 
         self.destinations(results, &status);
 
-        if (!status) {
-            throw std::runtime_error(status.errorString().asChar());
-        }
+        CHECK_STATUS(status)
 
         return atov::convert(results);  
     }, R"pbdoc(If this plug is a source, return the destination plugs connected to it.
@@ -209,9 +197,7 @@ This method will produce the networked version of the connected plug.)pbdoc")
 
         self.destinationsWithConversions(results, &status);
 
-        if (!status) {
-            throw std::runtime_error(status.errorString().asChar());
-        }
+        CHECK_STATUS(status)
 
         return atov::convert(results);  
     }, R"pbdoc(If this plug is a source, return the destination plugs connected to it.
@@ -235,10 +221,8 @@ Note that the behavior of connectedTo() is identical to destinationsWithConversi
 
         MStatus status;
         MPlug result = self.elementByLogicalIndex(index, &status);
-
-        if (!status) {
-            throw std::runtime_error(status.errorString().asChar());
-        }
+        
+        CHECK_STATUS(status)
 
         return result;
     }, R"pbdoc(Returns a plug for the element of this plug array having the specified logical index.)pbdoc")
@@ -263,9 +247,7 @@ Note that the behavior of connectedTo() is identical to destinationsWithConversi
         MStatus status;
         MPlug result = self.elementByPhysicalIndex(index, &status);
 
-        if (!status) {
-            throw std::runtime_error(status.errorString().asChar());
-        }
+        CHECK_STATUS(status)
 
         return result;
     }, R"pbdoc(Returns a plug for the element of this plug array having the specified physical index. )pbdoc")
@@ -283,9 +265,7 @@ Note that the behavior of connectedTo() is identical to destinationsWithConversi
         MStatus status;
         unsigned int result = self.evaluateNumElements(&status);
 
-        if (!status) {
-            throw std::runtime_error(status.errorString().asChar());
-        }
+        CHECK_STATUS(status)
 
         return result;     
     }, R"pbdoc(Like numElements() but evaluates all connected elements first to ensure that they are included in the count.)pbdoc")
@@ -305,9 +285,7 @@ Note that the behavior of connectedTo() is identical to destinationsWithConversi
         
         self.getExistingArrayAttributeIndices(results, &status);
 
-        if (!status) {
-            throw std::runtime_error(status.errorString().asChar());
-        }
+        CHECK_STATUS(status)
 
         return atov::convert(results);
     }, R"pbdoc(Returns an array of all the plug's logical indices which are currently in use.)pbdoc")
@@ -403,9 +381,7 @@ Note that the behavior of connectedTo() is identical to destinationsWithConversi
         MStatus status;
         unsigned int result = self.logicalIndex(&status);
 
-        if (!status) {
-            throw std::runtime_error(status.errorString().asChar());
-        }
+        CHECK_STATUS(status)
 
         return result; 
     }, R"pbdoc(Returns this plug's logical index within its parent array.)pbdoc")
@@ -420,9 +396,7 @@ Note that the behavior of connectedTo() is identical to destinationsWithConversi
         MStatus status;
         MObject result = self.node(&status);
 
-        if (!status) {
-            throw std::runtime_error(status.errorString().asChar());
-        }
+        CHECK_STATUS(status)
 
         return result; 
     }, R"pbdoc(Returns the node that this plug belongs to.)pbdoc")
@@ -440,9 +414,7 @@ Note that the behavior of connectedTo() is identical to destinationsWithConversi
         MStatus status;
         unsigned int result = self.numChildren(&status);
 
-        if (!status) {
-            throw std::runtime_error(status.errorString().asChar());
-        }
+        CHECK_STATUS(status)
 
         return result;  
     }, R"pbdoc(Returns the number of children this plug has.)pbdoc")
@@ -468,9 +440,7 @@ Note that the behavior of connectedTo() is identical to destinationsWithConversi
         MStatus status;
         unsigned int result = self.numElements(&status);
 
-        if (!status) {
-            throw std::runtime_error(status.errorString().asChar());
-        }
+        CHECK_STATUS(status)
 
         return result; 
     }, R"pbdoc(Returns the number of the plug's logical indices which are currently in use. Connected elements which have not yet been evaluated may not yet fully exist and may be excluded from the count.)pbdoc")
@@ -488,9 +458,7 @@ Note that the behavior of connectedTo() is identical to destinationsWithConversi
         MStatus status;
         MPlug result = self.parent(&status);
 
-        if (!status) {
-            throw std::runtime_error(status.errorString().asChar());
-        }
+        CHECK_STATUS(status)
 
         return result;     
     }, R"pbdoc(Returns a plug for the parent of this plug.)pbdoc")
@@ -569,9 +537,7 @@ Note that the behavior of connectedTo() is identical to destinationsWithConversi
         MStatus status;
         MPlug result = self.source(&status);
 
-        if (!status) {
-            throw std::runtime_error(status.errorString().asChar());
-        }
+        CHECK_STATUS(status)
 
         return result;      
     }, R"pbdoc(If this plug is a destination, return the source plug connected to it.
@@ -584,9 +550,7 @@ This method will produce the networked version of the connectedplug.)pbdoc")
         MStatus status;
         MPlug result = self.sourceWithConversion(&status);
 
-        if (!status) {
-            throw std::runtime_error(status.errorString().asChar());
-        }
+        CHECK_STATUS(status)
 
         return result;       
     }, R"pbdoc(If this plug is a destination, return the source plug connected to it.

--- a/src/MPlug.inl
+++ b/src/MPlug.inl
@@ -256,8 +256,28 @@ Note that the behavior of connectedTo() is identical to destinationsWithConversi
         return result;     
     }, R"pbdoc(Like numElements() but evaluates all connected elements first to ensure that they are included in the count.)pbdoc")
 
-    .def("getExistingArrayAttributeIndices", [](MPlug & self, MIntArray indices) -> int {
-        throw std::logic_error{"Function not yet implemented."};
+    .def("getExistingArrayAttributeIndices", [](MPlug & self) -> std::vector<int> {
+        if (self.isNull()) {
+            throw std::invalid_argument("Accessed a null plug.");
+        }
+
+        if (!self.isArray()) {
+            MString error_msg("Plug '^1s' is not an array plug.");
+                    error_msg.format(error_msg, self.name());
+
+            throw pybind11::type_error(error_msg.asChar());
+        }
+
+        MStatus status;
+        MIntArray results;
+        
+        self.getExistingArrayAttributeIndices(results, &status);
+
+        if (!status) {
+            throw std::runtime_error(status.errorString().asChar());
+        }
+
+        return atov::convert(results);
     }, R"pbdoc(Returns an array of all the plug's logical indices which are currently in use.)pbdoc")
 
     .def("getSetAttrCmds", [](MPlug & self, MPlug::MValueSelector valueSelector = MPlug::MValueSelector::kAll, bool useLongNames = false) -> std::vector<std::string> {

--- a/src/MPlug.inl
+++ b/src/MPlug.inl
@@ -170,8 +170,20 @@ plug.def(py::init<>())
         return result;    
     }, R"pbdoc(Returns a plug for the specified child attribute of this plug.)pbdoc")
 
-    .def("connectedTo", [](MPlug & self, std::vector<MPlug> array, bool asDst, bool asSrc) -> bool {
-        throw std::logic_error{"Function not yet implemented."};
+    .def("connectedTo", [](MPlug & self, bool asDst, bool asSrc) -> std::vector<MPlug> {
+        if (self.isNull()) {
+            throw std::invalid_argument("Accessed a null plug.");
+        }
+
+        MStatus status;
+        MPlugArray results;
+        self.connectedTo(results, asDst, asSrc, &status);
+
+        if (!status) {
+            throw std::runtime_error(status.errorString().asChar());
+        }
+
+        return atov::convert(results);   
     }, R"pbdoc(Returns an array of plugs which are connected to this one.)pbdoc")
 
     .def("connectionByPhysicalIndex", [](MPlug & self, unsigned int physicalIndex) -> MPlug {

--- a/src/MPlug.inl
+++ b/src/MPlug.inl
@@ -202,7 +202,21 @@ If this plug is not a source, a null plug is returned.
 This method will produce the networked version of the connected plug.)pbdoc")
 
     .def("destinationsWithConversions", [](MPlug & self) -> std::vector<MPlug> {
-        throw std::logic_error{"Function not yet implemented."};
+
+        if (self.isNull()) {
+            throw std::invalid_argument("Accessed a null plug.");
+        }
+        
+        MPlugArray results;
+        MStatus status;
+
+        self.destinationsWithConversions(results, &status);
+
+        if (!status) {
+            throw std::runtime_error(status.errorString().asChar());
+        }
+
+        return atov::convert(results);  
     }, R"pbdoc(If this plug is a source, return the destination plugs connected to it.
 This method is very similar to the destinations() method.  The only difference is that the destinations() method skips over any unit conversion node connected to this source, and returns the destination of the unit conversion node.
 destinationsWithConversionNode() does not skip over unit conversion nodes, and returns the destination plug on a unit conversion node, if present.

--- a/src/MPlug.inl
+++ b/src/MPlug.inl
@@ -222,59 +222,59 @@ Note that the behavior of connectedTo() is identical to destinationsWithConversi
     }, R"pbdoc(Description of the plug for debugging purposes, in the form node:attr1.attr2[].attr3...)pbdoc")
 
     .def("isArray", [](MPlug & self) -> bool {
-        throw std::logic_error{"Function not yet implemented."};
+        return self.isArray();
     }, R"pbdoc(True if plug is an array of plugs.)pbdoc")
 
     .def("isChild", [](MPlug & self) -> bool {
-        throw std::logic_error{"Function not yet implemented."};
+        return self.isChild();
     }, R"pbdoc(True if plug is a child of a compound parent.)pbdoc")
 
     .def("isCompound", [](MPlug & self) -> bool {
-        throw std::logic_error{"Function not yet implemented."};
+        return self.isCompound();
     }, R"pbdoc(True if plug is compound parent with children.)pbdoc")
 
     .def("isConnected", [](MPlug & self) -> bool {
-        throw std::logic_error{"Function not yet implemented."};
+        return self.isConnected();
     }, R"pbdoc(True if plug has any connections.)pbdoc")
 
     .def("isDefaultValue", [](MPlug & self, bool forceEval = true) -> bool {
-        throw std::logic_error{"Function not yet implemented."};
+        return self.isDefaultValue(forceEval);
     }, R"pbdoc(Returns a value indicating if the plug's value is equivalent to the plug's default value.)pbdoc")
 
     .def("isDestination", [](MPlug & self) -> bool {
-        throw std::logic_error{"Function not yet implemented."};
+        return self.isDestination();
     }, R"pbdoc(True if plug is the destination of a connection.)pbdoc")
 
     .def("isDynamic", [](MPlug & self) -> bool {
-        throw std::logic_error{"Function not yet implemented."};
+        return self.isDynamic();
     }, R"pbdoc(True if plug is for a dynamic attribute.)pbdoc")
 
     .def("isElement", [](MPlug & self) -> bool {
-        throw std::logic_error{"Function not yet implemented."};
+        return self.isElement();
     }, R"pbdoc(True if plug is an element of an array of plugs.)pbdoc")
 
     .def("isFreeToChange", [](MPlug & self, bool checkParents = true, bool checkChildren = true) -> MPlug::FreeToChangeState {
-        throw std::logic_error{"Function not yet implemented."};
+        return self.isFreeToChange(checkParents, checkChildren);
     }, R"pbdoc(Returns a value indicating if the plug's value can be changed, after taking into account the effects of locking and connections.)pbdoc")
 
     .def("isFromReferencedFile", [](MPlug & self) -> bool {
-        throw std::logic_error{"Function not yet implemented."};
+        return self.isFromReferencedFile();
     }, R"pbdoc(True if plug is part of a connection from a referenced file.)pbdoc")
 
     .def("isIgnoredWhenRendering", [](MPlug & self) -> bool {
-        throw std::logic_error{"Function not yet implemented."};
+        return self.isIgnoredWhenRendering();
     }, R"pbdoc(True if connetions to plug are ignored during rendering.)pbdoc")
 
     .def("isKeyable", [](MPlug & self) -> bool {
-        throw std::logic_error{"Function not yet implemented."};
+        return self.isKeyable();
     }, R"pbdoc(True if keys can be set on plug from Maya's UI.)pbdoc")
 
     .def("isLocked", [](MPlug & self) -> bool {
-        throw std::logic_error{"Function not yet implemented."};
+        return self.isLocked();
     }, R"pbdoc(True if plug is locked against changes.)pbdoc")
 
     .def("isNetworked", [](MPlug & self) -> bool {
-        throw std::logic_error{"Function not yet implemented."};
+        return self.isNetworked();    
     }, R"pbdoc(True if plug is networked.)pbdoc")
 
     .def("isNull", [](MPlug & self) -> bool {
@@ -282,11 +282,11 @@ Note that the behavior of connectedTo() is identical to destinationsWithConversi
     }, R"pbdoc(True if plug does not reference an attribute.)pbdoc")
 
     .def("isProcedural", [](MPlug & self) -> bool {
-        throw std::logic_error{"Function not yet implemented."};
+        return self.isProcedural();
     }, R"pbdoc(True if plug is procedural.)pbdoc")
 
     .def("isSource", [](MPlug & self) -> bool {
-        throw std::logic_error{"Function not yet implemented."};
+        return self.isSource();
     }, R"pbdoc(True if plug is the source of a connection.)pbdoc")
 
     .def("logicalIndex", [](MPlug & self) -> int {

--- a/src/MPlug.inl
+++ b/src/MPlug.inl
@@ -79,7 +79,18 @@ plug.def(py::init<>())
     }, R"pbdoc(Retrieves the plug's value, as a string.)pbdoc")
 
     .def("attribute", [](MPlug & self) -> MObject {
-        throw std::logic_error{"Function not yet implemented."};
+        if (self.isNull()) {
+            throw std::invalid_argument("Accessed a null plug.");
+        }
+
+        MStatus status;
+        MObject result = self.attribute(&status);
+
+        if (!status) {
+            throw std::runtime_error(status.errorString().asChar());
+        }
+
+        return result;    
     }, R"pbdoc(Returns the attribute currently referenced by this plug.)pbdoc")
 
     .def("child", [](MPlug & self, MObject attr) -> MPlug {

--- a/src/MPlug.inl
+++ b/src/MPlug.inl
@@ -234,8 +234,26 @@ Note that the behavior of connectedTo() is identical to destinationsWithConversi
         throw std::logic_error{"Function not yet implemented."};
     }, R"pbdoc(Returns a plug for the element of this plug array having the specified physical index. )pbdoc")
 
-    .def("evaluateNumElements", [](MPlug & self) -> int {
-        throw std::logic_error{"Function not yet implemented."};
+    .def("evaluateNumElements", [](MPlug & self) -> unsigned int {
+        if (self.isNull()) {
+            throw std::invalid_argument("Accessed a null plug.");
+        }
+
+        if (!self.isArray()) {
+            MString error_msg("Plug '^1s' is not an array plug.");
+                    error_msg.format(error_msg, self.name());
+
+            throw pybind11::type_error(error_msg.asChar());
+        }
+
+        MStatus status;
+        unsigned int result = self.evaluateNumElements(&status);
+
+        if (!status) {
+            throw std::runtime_error(status.errorString().asChar());
+        }
+
+        return result;     
     }, R"pbdoc(Like numElements() but evaluates all connected elements first to ensure that they are included in the count.)pbdoc")
 
     .def("getExistingArrayAttributeIndices", [](MPlug & self, MIntArray indices) -> int {

--- a/src/MPlug.inl
+++ b/src/MPlug.inl
@@ -339,8 +339,10 @@ Note that the behavior of connectedTo() is identical to destinationsWithConversi
         throw std::logic_error{"Function not yet implemented."};
     }, R"pbdoc(Returns a list of strings containing the setAttr commands (in MEL syntax) for this plug and all of its descendents.)pbdoc")
 
-    .def("info", [](MPlug & self) -> MString {
-        throw std::logic_error{"Function not yet implemented."};
+    .def("info", [](MPlug & self) -> std::string {
+        MString result = self.info();
+
+        return std::string(result.asChar());
     }, R"pbdoc(Description of the plug for debugging purposes, in the form node:attr1.attr2[].attr3...)pbdoc")
 
     .def("isArray", [](MPlug & self) -> bool {

--- a/src/MPlug.inl
+++ b/src/MPlug.inl
@@ -11,9 +11,7 @@ plug.def(py::init<>())
     .def(py::self == MPlug())
 
     .def("array", [](MPlug & self) -> MPlug {
-        if (self.isNull()) {
-            throw std::invalid_argument("Accessed a null plug.");
-        }
+        plug::assert_not_null(self);
 
         if (!self.isElement()) {
             MString error_msg("Plug '^1s' is not an array element.");
@@ -81,9 +79,7 @@ plug.def(py::init<>())
     }, R"pbdoc(Retrieves the plug's value, as a string.)pbdoc")
 
     .def("attribute", [](MPlug & self) -> MObject {
-        if (self.isNull()) {
-            throw std::invalid_argument("Accessed a null plug.");
-        }
+        plug::assert_not_null(self);
 
         MStatus status;
         MObject result = self.attribute(&status);
@@ -96,9 +92,7 @@ plug.def(py::init<>())
     }, R"pbdoc(Returns the attribute currently referenced by this plug.)pbdoc")
 
     .def("child", [](MPlug & self, MObject attr) -> MPlug {
-        if (self.isNull()) {
-            throw std::invalid_argument("Accessed a null plug.");
-        }
+        plug::assert_not_null(self);
 
         if ((self.isCompound() && self.isArray()) || !self.isCompound()) {
             MString error_msg("Plug '^1s' is not a compound plug or is a compound array plug.");
@@ -142,9 +136,7 @@ plug.def(py::init<>())
     }, R"pbdoc(Returns a plug for the specified child attribute of this plug.)pbdoc")
 
     .def("child", [](MPlug & self, unsigned int index) -> MPlug {
-        if (self.isNull()) {
-            throw std::invalid_argument("Accessed a null plug.");
-        }
+        plug::assert_not_null(self);
 
         if ((self.isCompound() && self.isArray()) || !self.isCompound()) {
             MString error_msg("Plug '^1s' is not a compound plug or is a compound array plug.");
@@ -171,9 +163,7 @@ plug.def(py::init<>())
     }, R"pbdoc(Returns a plug for the specified child attribute of this plug.)pbdoc")
 
     .def("connectedTo", [](MPlug & self, bool asDst, bool asSrc) -> std::vector<MPlug> {
-        if (self.isNull()) {
-            throw std::invalid_argument("Accessed a null plug.");
-        }
+        plug::assert_not_null(self);
 
         MStatus status;
         MPlugArray results;
@@ -195,10 +185,8 @@ plug.def(py::init<>())
     }, R"pbdoc(Constructs a data handle for the plug.)pbdoc")
 
     .def("destinations", [](MPlug & self) -> std::vector<MPlug> {
-        if (self.isNull()) {
-            throw std::invalid_argument("Accessed a null plug.");
-        }
-        
+        plug::assert_not_null(self);
+
         MPlugArray results;
         MStatus status;
 
@@ -214,10 +202,7 @@ If this plug is not a source, a null plug is returned.
 This method will produce the networked version of the connected plug.)pbdoc")
 
     .def("destinationsWithConversions", [](MPlug & self) -> std::vector<MPlug> {
-
-        if (self.isNull()) {
-            throw std::invalid_argument("Accessed a null plug.");
-        }
+        plug::assert_not_null(self);
         
         MPlugArray results;
         MStatus status;
@@ -239,9 +224,7 @@ Note that the behavior of connectedTo() is identical to destinationsWithConversi
     }, R"pbdoc(Destroys a data handle previously constructed using constructHandle().)pbdoc")
 
     .def("elementByLogicalIndex", [](MPlug & self, unsigned int index) -> MPlug {
-        if (self.isNull()) {
-            throw std::invalid_argument("Accessed a null plug.");
-        }
+        plug::assert_not_null(self);
 
         if (!self.isArray()) {
             MString error_msg("Plug '^1s' is not an array plug.");
@@ -261,9 +244,7 @@ Note that the behavior of connectedTo() is identical to destinationsWithConversi
     }, R"pbdoc(Returns a plug for the element of this plug array having the specified logical index.)pbdoc")
 
     .def("elementByPhysicalIndex", [](MPlug & self, unsigned int index) -> MPlug {
-        if (self.isNull()) {
-            throw std::invalid_argument("Accessed a null plug.");
-        }
+        plug::assert_not_null(self);
 
         if (!self.isArray()) {
             MString error_msg("Plug '^1s' is not an array plug.");
@@ -290,9 +271,7 @@ Note that the behavior of connectedTo() is identical to destinationsWithConversi
     }, R"pbdoc(Returns a plug for the element of this plug array having the specified physical index. )pbdoc")
 
     .def("evaluateNumElements", [](MPlug & self) -> unsigned int {
-        if (self.isNull()) {
-            throw std::invalid_argument("Accessed a null plug.");
-        }
+        plug::assert_not_null(self);
 
         if (!self.isArray()) {
             MString error_msg("Plug '^1s' is not an array plug.");
@@ -312,9 +291,7 @@ Note that the behavior of connectedTo() is identical to destinationsWithConversi
     }, R"pbdoc(Like numElements() but evaluates all connected elements first to ensure that they are included in the count.)pbdoc")
 
     .def("getExistingArrayAttributeIndices", [](MPlug & self) -> std::vector<int> {
-        if (self.isNull()) {
-            throw std::invalid_argument("Accessed a null plug.");
-        }
+        plug::assert_not_null(self);
 
         if (!self.isArray()) {
             MString error_msg("Plug '^1s' is not an array plug.");
@@ -414,9 +391,7 @@ Note that the behavior of connectedTo() is identical to destinationsWithConversi
     }, R"pbdoc(True if plug is the source of a connection.)pbdoc")
 
     .def("logicalIndex", [](MPlug & self) -> unsigned int {
-       if (self.isNull()) {
-            throw std::invalid_argument("Accessed a null plug.");
-        }
+        plug::assert_not_null(self);
 
         if (!self.isElement()) {
             MString error_msg("Plug '^1s' is not an array element plug.");
@@ -453,9 +428,7 @@ Note that the behavior of connectedTo() is identical to destinationsWithConversi
     }, R"pbdoc(Returns the node that this plug belongs to.)pbdoc")
 
     .def("numChildren", [](MPlug & self) -> unsigned int {
-        if (self.isNull()) {
-            throw std::invalid_argument("Accessed a null plug.");
-        }
+        plug::assert_not_null(self);
 
         if (!self.isCompound()) {
             MString error_msg("Plug '^1s' is not a compound plug.");
@@ -483,9 +456,7 @@ Note that the behavior of connectedTo() is identical to destinationsWithConversi
     }, R"pbdoc(Returns the number of this plug's elements which have connections.)pbdoc")
 
     .def("numElements", [](MPlug & self) -> unsigned int {
-        if (self.isNull()) {
-            throw std::invalid_argument("Accessed a null plug.");
-        }
+        plug::assert_not_null(self);
 
         if (!self.isArray()) {
             MString error_msg("Plug '^1s' is not an array plug.");
@@ -505,9 +476,7 @@ Note that the behavior of connectedTo() is identical to destinationsWithConversi
     }, R"pbdoc(Returns the number of the plug's logical indices which are currently in use. Connected elements which have not yet been evaluated may not yet fully exist and may be excluded from the count.)pbdoc")
 
     .def("parent", [](MPlug & self) -> MPlug {
-        if (self.isNull()) {
-            throw std::invalid_argument("Accessed a null plug.");
-        }
+        plug::assert_not_null(self);
 
         if (!self.isChild()) {
             MString error_msg("Plug '^1s' is not a child plug.");
@@ -595,9 +564,7 @@ Note that the behavior of connectedTo() is identical to destinationsWithConversi
     }, R"pbdoc(Sets the plug's value as a string.)pbdoc")
 
     .def("source", [](MPlug & self) -> MPlug {
-        if (self.isNull()) {
-            throw std::invalid_argument("Accessed a null plug.");
-        }
+        plug::assert_not_null(self);
 
         MStatus status;
         MPlug result = self.source(&status);
@@ -612,9 +579,7 @@ If this plug is not a destination, a null plug is returned.
 This method will produce the networked version of the connectedplug.)pbdoc")
 
     .def("sourceWithConversion", [](MPlug & self) -> MPlug {
-       if (self.isNull()) {
-            throw std::invalid_argument("Accessed a null plug.");
-        }
+        plug::assert_not_null(self);
 
         MStatus status;
         MPlug result = self.sourceWithConversion(&status);

--- a/src/MPlug.inl
+++ b/src/MPlug.inl
@@ -365,7 +365,25 @@ Note that the behavior of connectedTo() is identical to destinationsWithConversi
     }, R"pbdoc(Returns the number of the plug's logical indices which are currently in use. Connected elements which have not yet been evaluated may not yet fully exist and may be excluded from the count.)pbdoc")
 
     .def("parent", [](MPlug & self) -> MPlug {
-        throw std::logic_error{"Function not yet implemented."};
+        if (self.isNull()) {
+            throw std::invalid_argument("Accessed a null plug.");
+        }
+
+        if (!self.isChild()) {
+            MString error_msg("Plug '^1s' is not a child plug.");
+                    error_msg.format(error_msg, self.name());
+
+            throw pybind11::type_error(error_msg.asChar());
+        }
+
+        MStatus status;
+        MPlug result = self.parent(&status);
+
+        if (!status) {
+            throw std::runtime_error(status.errorString().asChar());
+        }
+
+        return result;     
     }, R"pbdoc(Returns a plug for the parent of this plug.)pbdoc")
 
     .def("partialName", [](MPlug & self, bool includeNodeName = false, bool includeNonMandatoryIndices = false, bool includeInstancedIndices = false, bool useAlias = false, bool useFullAttributePath = false, bool useLongNames = false) -> MString {

--- a/src/MPlug.inl
+++ b/src/MPlug.inl
@@ -8,6 +8,8 @@ py::enum_<MPlug::MValueSelector>(plug, "ValueSelector")
 
 plug.def(py::init<>())
 
+    .def(py::self == MPlug())
+
     .def("array", [](MPlug & self) -> MPlug {
         if (self.isNull()) {
             throw std::invalid_argument("Accessed a null plug.");
@@ -399,13 +401,35 @@ Note that the behavior of connectedTo() is identical to destinationsWithConversi
     }, R"pbdoc(Sets the plug's value as a string.)pbdoc")
 
     .def("source", [](MPlug & self) -> MPlug {
-        throw std::logic_error{"Function not yet implemented."};
+        if (self.isNull()) {
+            throw std::invalid_argument("Accessed a null plug.");
+        }
+
+        MStatus status;
+        MPlug result = self.source(&status);
+
+        if (!status) {
+            throw std::runtime_error(status.errorString().asChar());
+        }
+
+        return result;      
     }, R"pbdoc(If this plug is a destination, return the source plug connected to it.
 If this plug is not a destination, a null plug is returned.
 This method will produce the networked version of the connectedplug.)pbdoc")
 
     .def("sourceWithConversion", [](MPlug & self) -> MPlug {
-        throw std::logic_error{"Function not yet implemented."};
+       if (self.isNull()) {
+            throw std::invalid_argument("Accessed a null plug.");
+        }
+
+        MStatus status;
+        MPlug result = self.sourceWithConversion(&status);
+
+        if (!status) {
+            throw std::runtime_error(status.errorString().asChar());
+        }
+
+        return result;       
     }, R"pbdoc(If this plug is a destination, return the source plug connected to it.
 This method is very similar to the source() method.  The only difference is that the source() method skips over any unit conversionnode connected to this destination, and returns the source of the unit conversion node.
 sourceWithConversion() does not skip over unitconversion nodes, and returns the source plug on a unit conversionnode, if present.

--- a/src/MPlug.inl
+++ b/src/MPlug.inl
@@ -9,312 +9,25 @@ py::enum_<MPlug::MValueSelector>(plug, "ValueSelector")
 plug.def(py::init<>())
 
     .def("array", [](MPlug & self) -> MPlug {
-        throw std::logic_error{"Function not yet implemented."};
-    }, R"pbdoc(Returns a plug for the array of plugs of which this plug is an element.)pbdoc")
+        if (self.isNull()) {
+            throw std::invalid_argument("Accessed a null plug.");
+        }
 
-    .def("asBool", [](MPlug & self) -> bool {
-        throw std::logic_error{"Function not yet implemented."};
-    }, R"pbdoc(Retrieves the plug's value, as a boolean.)pbdoc")
+        if (!self.isElement()) {
+            MString error_msg("Plug '^1s' is not an array element.");
+                    error_msg.format(error_msg, self.name());
 
-    .def("asChar", [](MPlug & self) -> char {
-        throw std::logic_error{"Function not yet implemented."};
-    }, R"pbdoc(Retrieves the plug's value, as a single-byte integer.)pbdoc")
+            throw pybind11::type_error(error_msg.asChar());
+        }
 
-    .def("asDouble", [](MPlug & self) -> double {
-        throw std::logic_error{"Function not yet implemented."};
-    }, R"pbdoc(Retrieves the plug's value, as a double-precision float.)pbdoc")
-
-    .def("asFloat", [](MPlug & self) -> float {
-        throw std::logic_error{"Function not yet implemented."};
-    }, R"pbdoc(Retrieves the plug's value, as a single-precision float.)pbdoc")
-
-    .def("asInt", [](MPlug & self) -> int {
-        throw std::logic_error{"Function not yet implemented."};
-    }, R"pbdoc(Retrieves the plug's value, as a regular integer.)pbdoc")
-
-    .def("asMAngle", [](MPlug & self) -> MAngle {
-        throw std::logic_error{"Function not yet implemented."};
-    }, R"pbdoc(Retrieves the plug's value, as an MAngle.)pbdoc")
-
-    .def("asMDataHandle", [](MPlug & self) -> MDataHandle {
-        throw std::logic_error{"Function not yet implemented."};
-    }, R"pbdoc(Retrieve the current value of the attribute this plug references.)pbdoc")
-
-    .def("asMDistance", [](MPlug & self) -> MDistance {
-        throw std::logic_error{"Function not yet implemented."};
-    }, R"pbdoc(Retrieves the plug's value, as an MDistance.)pbdoc")
-
-    .def("asMObject", [](MPlug & self) -> MObject {
-        throw std::logic_error{"Function not yet implemented."};
-    }, R"pbdoc(Retrieves the plug's value, as as an MObject containing a direct reference to the plug's data.)pbdoc")
-
-    .def("asMTime", [](MPlug & self) -> MTime {
-        throw std::logic_error{"Function not yet implemented."};
-    }, R"pbdoc(Retrieves the plug's value, as an MTime.)pbdoc")
-
-    .def("asShort", [](MPlug & self) -> short {
-        throw std::logic_error{"Function not yet implemented."};
-    }, R"pbdoc(Retrieves the plug's value, as a short integer.)pbdoc")
-
-    .def("asString", [](MPlug & self) -> MString {
-        throw std::logic_error{"Function not yet implemented."};
-    }, R"pbdoc(Retrieves the plug's value, as a string.)pbdoc")
-
-    .def("attribute", [](MPlug & self) -> MObject {
-        throw std::logic_error{"Function not yet implemented."};
-    }, R"pbdoc(Returns the attribute currently referenced by this plug.)pbdoc")
-
-    .def("child", [](MPlug & self, MObject attr) -> MPlug {
-        throw std::logic_error{"Function not yet implemented."};
-    }, R"pbdoc(Returns a plug for the specified child attribute of this plug.)pbdoc")
-
-    .def("child", [](MPlug & self, unsigned int index) -> MPlug {
-        throw std::logic_error{"Function not yet implemented."};
-    }, R"pbdoc(Returns a plug for the specified child attribute of this plug.)pbdoc")
-
-    .def("connectedTo", [](MPlug & self, std::vector<MPlug> array, bool asDst, bool asSrc) -> bool {
-        throw std::logic_error{"Function not yet implemented."};
-    }, R"pbdoc(Returns an array of plugs which are connected to this one.)pbdoc")
-
-    .def("connectionByPhysicalIndex", [](MPlug & self, unsigned int physicalIndex) -> MPlug {
-        throw std::logic_error{"Function not yet implemented."};
-    }, R"pbdoc(Returns a plug for the index'th connected element of this plug.)pbdoc")
-
-    .def("constructHandle", [](MPlug & self, MDataBlock) -> MDataHandle {
-        throw std::logic_error{"Function not yet implemented."};
-    }, R"pbdoc(Constructs a data handle for the plug.)pbdoc")
-
-    .def("destinations", [](MPlug & self, std::vector<MPlug> theDestinations) -> bool {
-        throw std::logic_error{"Function not yet implemented."};
-    }, R"pbdoc(If this plug is a source, return the destination plugs connected to it.
-If this plug is not a source, a null plug is returned.
-This method will produce the networked version of the connected plug.)pbdoc")
-
-    .def("destinationsWithConversions", [](MPlug & self, std::vector<MPlug> theDestinations) -> bool {
-        throw std::logic_error{"Function not yet implemented."};
-    }, R"pbdoc(If this plug is a source, return the destination plugs connected to it.
-This method is very similar to the destinations() method.  The only difference is that the destinations() method skips over any unit conversion node connected to this source, and returns the destination of the unit conversion node.
-destinationsWithConversionNode() does not skip over unit conversion nodes, and returns the destination plug on a unit conversion node, if present.
-Note that the behavior of connectedTo() is identical to destinationsWithConversions(), that is, do not skip over unit conversion nodes.)pbdoc")
-
-    .def("destructHandle", [](MPlug & self, MDataHandle) -> void {
-        throw std::logic_error{"Function not yet implemented."};
-    }, R"pbdoc(Destroys a data handle previously constructed using constructHandle().)pbdoc")
-
-    .def("elementByLogicalIndex", [](MPlug & self, unsigned int logicalIndex) -> MPlug {
-        throw std::logic_error{"Function not yet implemented."};
-    }, R"pbdoc(Returns a plug for the element of this plug array having the specified logical index.)pbdoc")
-
-    .def("elementByPhysicalIndex", [](MPlug & self, unsigned int physicalIndex) -> MPlug {
-        throw std::logic_error{"Function not yet implemented."};
-    }, R"pbdoc(Returns a plug for the element of this plug array having the specified physical index. )pbdoc")
-
-    .def("evaluateNumElements", [](MPlug & self) -> int {
-        throw std::logic_error{"Function not yet implemented."};
-    }, R"pbdoc(Like numElements() but evaluates all connected elements first to ensure that they are included in the count.)pbdoc")
-
-    .def("getExistingArrayAttributeIndices", [](MPlug & self, MIntArray indices) -> int {
-        throw std::logic_error{"Function not yet implemented."};
-    }, R"pbdoc(Returns an array of all the plug's logical indices which are currently in use.)pbdoc")
-
-    .def("getSetAttrCmds", [](MPlug & self, MPlug::MValueSelector valueSelector = MPlug::MValueSelector::kAll, bool useLongNames = false) -> std::vector<std::string> {
-        throw std::logic_error{"Function not yet implemented."};
-    }, R"pbdoc(Returns a list of strings containing the setAttr commands (in MEL syntax) for this plug and all of its descendents.)pbdoc")
-
-    .def("info", [](MPlug & self) -> MString {
-        throw std::logic_error{"Function not yet implemented."};
-    }, R"pbdoc(Description of the plug for debugging purposes, in the form node:attr1.attr2[].attr3...)pbdoc")
-
-    .def("isArray", [](MPlug & self) -> bool {
-        throw std::logic_error{"Function not yet implemented."};
-    }, R"pbdoc(True if plug is an array of plugs.)pbdoc")
-
-    .def("isChild", [](MPlug & self) -> bool {
-        throw std::logic_error{"Function not yet implemented."};
-    }, R"pbdoc(True if plug is a child of a compound parent.)pbdoc")
-
-    .def("isCompound", [](MPlug & self) -> bool {
-        throw std::logic_error{"Function not yet implemented."};
-    }, R"pbdoc(True if plug is compound parent with children.)pbdoc")
-
-    .def("isConnected", [](MPlug & self) -> bool {
-        throw std::logic_error{"Function not yet implemented."};
-    }, R"pbdoc(True if plug has any connections.)pbdoc")
-
-    .def("isDefaultValue", [](MPlug & self, bool forceEval = true) -> bool {
-        throw std::logic_error{"Function not yet implemented."};
-    }, R"pbdoc(Returns a value indicating if the plug's value is equivalent to the plug's default value.)pbdoc")
-
-    .def("isDestination", [](MPlug & self) -> bool {
-        throw std::logic_error{"Function not yet implemented."};
-    }, R"pbdoc(True if plug is the destination of a connection.)pbdoc")
-
-    .def("isDynamic", [](MPlug & self) -> bool {
-        throw std::logic_error{"Function not yet implemented."};
-    }, R"pbdoc(True if plug is for a dynamic attribute.)pbdoc")
-
-    .def("isElement", [](MPlug & self) -> bool {
-        throw std::logic_error{"Function not yet implemented."};
-    }, R"pbdoc(True if plug is an element of an array of plugs.)pbdoc")
-
-    .def("isFreeToChange", [](MPlug & self, bool checkParents = true, bool checkChildren = true) -> MPlug::FreeToChangeState {
-        throw std::logic_error{"Function not yet implemented."};
-    }, R"pbdoc(Returns a value indicating if the plug's value can be changed, after taking into account the effects of locking and connections.)pbdoc")
-
-    .def("isFromReferencedFile", [](MPlug & self) -> bool {
-        throw std::logic_error{"Function not yet implemented."};
-    }, R"pbdoc(True if plug is part of a connection from a referenced file.)pbdoc")
-
-    .def("isIgnoredWhenRendering", [](MPlug & self) -> bool {
-        throw std::logic_error{"Function not yet implemented."};
-    }, R"pbdoc(True if connetions to plug are ignored during rendering.)pbdoc")
-
-    .def("isKeyable", [](MPlug & self) -> bool {
-        throw std::logic_error{"Function not yet implemented."};
-    }, R"pbdoc(True if keys can be set on plug from Maya's UI.)pbdoc")
-
-    .def("isLocked", [](MPlug & self) -> bool {
-        throw std::logic_error{"Function not yet implemented."};
-    }, R"pbdoc(True if plug is locked against changes.)pbdoc")
-
-    .def("isNetworked", [](MPlug & self) -> bool {
-        throw std::logic_error{"Function not yet implemented."};
-    }, R"pbdoc(True if plug is networked.)pbdoc")
-
-    .def("isNull", [](MPlug & self) -> bool {
-        return self.isNull();
-    }, R"pbdoc(True if plug does not reference an attribute.)pbdoc")
-
-    .def("isProcedural", [](MPlug & self) -> bool {
-        throw std::logic_error{"Function not yet implemented."};
-    }, R"pbdoc(True if plug is procedural.)pbdoc")
-
-    .def("isSource", [](MPlug & self) -> bool {
-        throw std::logic_error{"Function not yet implemented."};
-    }, R"pbdoc(True if plug is the source of a connection.)pbdoc")
-
-    .def("logicalIndex", [](MPlug & self) -> int {
-        throw std::logic_error{"Function not yet implemented."};
-    }, R"pbdoc(Returns this plug's logical index within its parent array.)pbdoc")
-
-    .def("name", [](MPlug & self) -> std::string {
-        return std::string(self.asString().asChar());
-    }, R"pbdoc(Returns the name of the plug.)pbdoc")
-
-    .def("node", [](MPlug & self) -> MObject {
         MStatus status;
-        MObject result = self.node(&status);
+        MPlug result = self.array(&status);
 
         if (!status) {
             throw std::runtime_error(status.errorString().asChar());
         }
 
-        return result; 
-    }, R"pbdoc(Returns the node that this plug belongs to.)pbdoc")
-
-    .def("numChildren", [](MPlug & self) -> int {
-        throw std::logic_error{"Function not yet implemented."};
-    }, R"pbdoc(Returns the number of children this plug has.)pbdoc")
-
-    .def("numConnectedChildren", [](MPlug & self) -> int {
-        throw std::logic_error{"Function not yet implemented."};
-    }, R"pbdoc(Returns the number of this plug's children which have connections.)pbdoc")
-
-    .def("numConnectedElements", [](MPlug & self) -> int {
-        throw std::logic_error{"Function not yet implemented."};
-    }, R"pbdoc(Returns the number of this plug's elements which have connections.)pbdoc")
-
-    .def("numElements", [](MPlug & self) -> int {
-        throw std::logic_error{"Function not yet implemented."};
-    }, R"pbdoc(Returns the number of the plug's logical indices which are currently in use. Connected elements which have not yet been evaluated may not yet fully exist and may be excluded from the count.)pbdoc")
-
-    .def("parent", [](MPlug & self) -> MPlug {
-        throw std::logic_error{"Function not yet implemented."};
-    }, R"pbdoc(Returns a plug for the parent of this plug.)pbdoc")
-
-    .def("partialName", [](MPlug & self, bool includeNodeName = false, bool includeNonMandatoryIndices = false, bool includeInstancedIndices = false, bool useAlias = false, bool useFullAttributePath = false, bool useLongNames = false) -> MString {
-        throw std::logic_error{"Function not yet implemented."};
-    }, R"pbdoc(Returns the name of the plug, formatted according to various criteria.)pbdoc")
-
-    .def("selectAncestorLogicalIndex", [](MPlug & self, unsigned int index, MObject attribute = MObject::kNullObj) {
-        throw std::logic_error{"Function not yet implemented."};
-    }, R"pbdoc(Changes the logical index of the specified attribute in the plug's path.)pbdoc")
-
-    .def("setAttribute", [](MPlug & self) -> MObject {
-        throw std::logic_error{"Function not yet implemented."};
-    }, R"pbdoc(Switches the plug to reference the given attribute of the same node as the previously referenced attribute.)pbdoc")
-
-    .def("setBool", [](MPlug & self, bool value) {
-        throw std::logic_error{"Function not yet implemented."};
-    }, R"pbdoc(Sets the plug's value as a boolean.)pbdoc")
-
-    .def("setChar", [](MPlug & self, char value) {
-        throw std::logic_error{"Function not yet implemented."};
-    }, R"pbdoc(Sets the plug's value as a single-byte integer.)pbdoc")
-
-    .def("setDouble", [](MPlug & self, double value) {
-        throw std::logic_error{"Function not yet implemented."};
-    }, R"pbdoc(Sets the plug's value as a double-precision float.)pbdoc")
-
-    .def("setFloat", [](MPlug & self, float value) {
-        throw std::logic_error{"Function not yet implemented."};
-    }, R"pbdoc(Sets the plug's value as a single-precision float.)pbdoc")
-
-    .def("setInt", [](MPlug & self, int value) {
-        throw std::logic_error{"Function not yet implemented."};
-    }, R"pbdoc(Sets the plug's value as a regular integer.)pbdoc")
-
-    .def("setMAngle", [](MPlug & self, MAngle angle) {
-        throw std::logic_error{"Function not yet implemented."};
-    }, R"pbdoc(Sets the plug's value as an MAngle.)pbdoc")
-
-    .def("setMDataHandle", [](MPlug & self, MDataHandle dataHandle) {
-        throw std::logic_error{"Function not yet implemented."};
-    }, R"pbdoc(Sets the plug's value as a data handle.)pbdoc")
-
-    .def("setMDistance", [](MPlug & self, MDistance distance) {
-        throw std::logic_error{"Function not yet implemented."};
-    }, R"pbdoc(Sets the plug's value as an MDistance.)pbdoc")
-
-    .def("setMObject", [](MPlug & self, MObject object) {
-        throw std::logic_error{"Function not yet implemented."};
-    }, R"pbdoc(Sets the plug's value as an MObject.)pbdoc")
-
-    .def("setMPxData", [](MPlug & self, MPxData *data) {
-        throw std::logic_error{"Function not yet implemented."};
-    }, R"pbdoc(Sets the plug's value using custom plug-in data.)pbdoc")
-
-    .def("setMTime", [](MPlug & self, MTime time) {
-        throw std::logic_error{"Function not yet implemented."};
-    }, R"pbdoc(Sets the plug's value as an MTime.)pbdoc")
-
-    .def("setNumElements", [](MPlug & self, unsigned int num_elements) {
-        throw std::logic_error{"Function not yet implemented."};
-    }, R"pbdoc(Pre-allocates space for count elements in an array of plugs.)pbdoc")
-
-    .def("setShort", [](MPlug & self, short value) {
-        throw std::logic_error{"Function not yet implemented."};
-    }, R"pbdoc(Sets the plug's value as a short integer.)pbdoc")
-
-    .def("setString", [](MPlug & self, MString value) {
-        throw std::logic_error{"Function not yet implemented."};
-    }, R"pbdoc(Sets the plug's value as a string.)pbdoc")
-
-    .def("source", [](MPlug & self) -> MPlug {
-        throw std::logic_error{"Function not yet implemented."};
-    }, R"pbdoc(If this plug is a destination, return the source plug connected to it.
-If this plug is not a destination, a null plug is returned.
-This method will produce the networked version of the connectedplug.)pbdoc")
-
-    .def("sourceWithConversion", [](MPlug & self) -> MPlug {
-        throw std::logic_error{"Function not yet implemented."};
-    }, R"pbdoc(If this plug is a destination, return the source plug connected to it.
-This method is very similar to the source() method.  The only difference is that the source() method skips over any unit conversionnode connected to this destination, and returns the source of the unit conversion node.
-sourceWithConversion() does not skip over unitconversion nodes, and returns the source plug on a unit conversionnode, if present.
-Note that the behavior of connectedTo() is identical to sourceWithConversion(), that is, do not skip over unit conversion nodes.)pbdoc") 
-
-    .def("array", [](MPlug & self) -> MPlug {
-        throw std::logic_error{"Function not yet implemented."};
+        return result;
     }, R"pbdoc(Returns a plug for the array of plugs of which this plug is an element.)pbdoc")
 
     .def("asBool", [](MPlug & self) -> bool {
@@ -503,7 +216,9 @@ Note that the behavior of connectedTo() is identical to destinationsWithConversi
     }, R"pbdoc(Returns this plug's logical index within its parent array.)pbdoc")
 
     .def("name", [](MPlug & self) -> std::string {
-        return std::string(self.asString().asChar());
+        MString result = self.name();  // TODO: error handling
+
+        return std::string(result.asChar());
     }, R"pbdoc(Returns the name of the plug.)pbdoc")
 
     .def("node", [](MPlug & self) -> MObject {

--- a/src/MPlug.inl
+++ b/src/MPlug.inl
@@ -226,12 +226,55 @@ Note that the behavior of connectedTo() is identical to destinationsWithConversi
         throw std::logic_error{"Function not yet implemented."};
     }, R"pbdoc(Destroys a data handle previously constructed using constructHandle().)pbdoc")
 
-    .def("elementByLogicalIndex", [](MPlug & self, unsigned int logicalIndex) -> MPlug {
-        throw std::logic_error{"Function not yet implemented."};
+    .def("elementByLogicalIndex", [](MPlug & self, unsigned int index) -> MPlug {
+        if (self.isNull()) {
+            throw std::invalid_argument("Accessed a null plug.");
+        }
+
+        if (!self.isArray()) {
+            MString error_msg("Plug '^1s' is not an array plug.");
+                    error_msg.format(error_msg, self.name());
+
+            throw pybind11::type_error(error_msg.asChar());
+        }
+
+        MStatus status;
+        MPlug result = self.elementByLogicalIndex(index, &status);
+
+        if (!status) {
+            throw std::runtime_error(status.errorString().asChar());
+        }
+
+        return result;
     }, R"pbdoc(Returns a plug for the element of this plug array having the specified logical index.)pbdoc")
 
-    .def("elementByPhysicalIndex", [](MPlug & self, unsigned int physicalIndex) -> MPlug {
-        throw std::logic_error{"Function not yet implemented."};
+    .def("elementByPhysicalIndex", [](MPlug & self, unsigned int index) -> MPlug {
+        if (self.isNull()) {
+            throw std::invalid_argument("Accessed a null plug.");
+        }
+
+        if (!self.isArray()) {
+            MString error_msg("Plug '^1s' is not an array plug.");
+                    error_msg.format(error_msg, self.name());
+
+            throw pybind11::type_error(error_msg.asChar());
+        }
+
+        if (index >= self.numElements()) {
+            MString error_msg("Plug '^1s' only has '^2s' elements.");
+                    error_msg.format(error_msg, self.name(), MString("") + self.numElements());
+                
+            throw std::out_of_range(error_msg.asChar());
+        }
+
+        MStatus status;
+        MPlug result = self.elementByPhysicalIndex(index, &status);
+
+        if (!status) {
+            throw std::runtime_error(status.errorString().asChar());
+        }
+
+        return result;
     }, R"pbdoc(Returns a plug for the element of this plug array having the specified physical index. )pbdoc")
 
     .def("evaluateNumElements", [](MPlug & self) -> unsigned int {

--- a/src/MPlug.inl
+++ b/src/MPlug.inl
@@ -312,8 +312,26 @@ Note that the behavior of connectedTo() is identical to destinationsWithConversi
         return result; 
     }, R"pbdoc(Returns the node that this plug belongs to.)pbdoc")
 
-    .def("numChildren", [](MPlug & self) -> int {
-        throw std::logic_error{"Function not yet implemented."};
+    .def("numChildren", [](MPlug & self) -> unsigned int {
+        if (self.isNull()) {
+            throw std::invalid_argument("Accessed a null plug.");
+        }
+
+        if (!self.isCompound()) {
+            MString error_msg("Plug '^1s' is not a compound plug.");
+                    error_msg.format(error_msg, self.name());
+
+            throw pybind11::type_error(error_msg.asChar());
+        }
+
+        MStatus status;
+        unsigned int result = self.numChildren(&status);
+
+        if (!status) {
+            throw std::runtime_error(status.errorString().asChar());
+        }
+
+        return result;  
     }, R"pbdoc(Returns the number of children this plug has.)pbdoc")
 
     .def("numConnectedChildren", [](MPlug & self) -> int {

--- a/src/MPlug.inl
+++ b/src/MPlug.inl
@@ -342,8 +342,26 @@ Note that the behavior of connectedTo() is identical to destinationsWithConversi
         throw std::logic_error{"Function not yet implemented."};
     }, R"pbdoc(Returns the number of this plug's elements which have connections.)pbdoc")
 
-    .def("numElements", [](MPlug & self) -> int {
-        throw std::logic_error{"Function not yet implemented."};
+    .def("numElements", [](MPlug & self) -> unsigned int {
+        if (self.isNull()) {
+            throw std::invalid_argument("Accessed a null plug.");
+        }
+
+        if (!self.isArray()) {
+            MString error_msg("Plug '^1s' is not an array plug.");
+                    error_msg.format(error_msg, self.name());
+
+            throw pybind11::type_error(error_msg.asChar());
+        }
+
+        MStatus status;
+        unsigned int result = self.numElements(&status);
+
+        if (!status) {
+            throw std::runtime_error(status.errorString().asChar());
+        }
+
+        return result; 
     }, R"pbdoc(Returns the number of the plug's logical indices which are currently in use. Connected elements which have not yet been evaluated may not yet fully exist and may be excluded from the count.)pbdoc")
 
     .def("parent", [](MPlug & self) -> MPlug {

--- a/src/MPlug.inl
+++ b/src/MPlug.inl
@@ -140,7 +140,32 @@ plug.def(py::init<>())
     }, R"pbdoc(Returns a plug for the specified child attribute of this plug.)pbdoc")
 
     .def("child", [](MPlug & self, unsigned int index) -> MPlug {
-        throw std::logic_error{"Function not yet implemented."};
+        if (self.isNull()) {
+            throw std::invalid_argument("Accessed a null plug.");
+        }
+
+        if ((self.isCompound() && self.isArray()) || !self.isCompound()) {
+            MString error_msg("Plug '^1s' is not a compound plug or is a compound array plug.");
+                    error_msg.format(error_msg, self.name());
+
+            throw pybind11::type_error(error_msg.asChar());
+        }
+
+        if (index >= self.numChildren()) {
+            MString error_msg("Plug '^1s' only has '^2s' children.");
+                    error_msg.format(error_msg, self.name(), MString("") + self.numChildren());
+                
+            throw std::out_of_range(error_msg.asChar());
+        }
+
+        MStatus status;
+        MPlug result = self.child(index, &status);
+
+        if (!status) {
+            throw std::runtime_error(status.errorString().asChar());
+        }
+
+        return result;    
     }, R"pbdoc(Returns a plug for the specified child attribute of this plug.)pbdoc")
 
     .def("connectedTo", [](MPlug & self, std::vector<MPlug> array, bool asDst, bool asSrc) -> bool {

--- a/src/MSelectionList.inl
+++ b/src/MSelectionList.inl
@@ -175,13 +175,7 @@ Raises IndexError if index is out of range.)pbdoc")
             throw std::runtime_error("Failed to get selection strings.");
         }
 
-        std::vector<std::string> result(strings.length());
-
-        for (unsigned int i = 0; i < strings.length(); i++) {
-            result[i] = std::string(strings[i].asChar());
-        }
-
-        return result;
+        return atov::convert(strings);
     }, R"pbdoc(getSelectionStrings(index=None) -> (string, string, ...)
 
 Returns a tuple containing the string representation of the
@@ -206,13 +200,7 @@ list are returned. Raises IndexError if index is out of bounds.)pbdoc")
             throw std::runtime_error("Failed to get selection strings.");
         }
 
-        std::vector<std::string> result(strings.length());
-
-        for (unsigned int i = 0; i < strings.length(); i++) {
-            result[i] = std::string(strings[i].asChar());
-        }
-
-        return result;
+        return atov::convert(strings);
     }, R"pbdoc(getSelectionStrings(index=None) -> (string, string, ...)
 
 Returns a tuple containing the string representation of the

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -18,6 +18,7 @@
 #include <maya/MDagPath.h>
 #include <maya/MEulerRotation.h>
 #include <maya/MFn.h>
+#include <maya/MIntArray.h>
 #include <maya/MMatrix.h>
 #include <maya/MObjectHandle.h>
 #include <maya/MPoint.h>

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -42,7 +42,7 @@
 
 #define STRINGIFY(x) #x
 #define MACRO_STRINGIFY(x) STRINGIFY(x)
-#define CHECK_STATUS(status) if (!status) throw std::invalid_argument("Bad status")
+#define CHECK_STATUS(status) if (!status) { throw std::runtime_error(status.errorString().asChar());}
 
 namespace py = pybind11;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -22,6 +22,7 @@
 #include <maya/MObjectHandle.h>
 #include <maya/MPoint.h>
 #include <maya/MPlug.h>
+#include <maya/MPlugArray.h>
 #include <maya/MPxData.h>
 #include <maya/MQuaternion.h>
 #include <maya/MSelectionList.h>
@@ -35,6 +36,7 @@
 // Function sets
 #include <maya/MFnDependencyNode.h>
 
+#include "util/atov.hpp"
 
 #define STRINGIFY(x) #x
 #define MACRO_STRINGIFY(x) STRINGIFY(x)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -38,6 +38,7 @@
 #include <maya/MFnDependencyNode.h>
 
 #include "util/atov.hpp"
+#include "util/plug.hpp"
 
 #define STRINGIFY(x) #x
 #define MACRO_STRINGIFY(x) STRINGIFY(x)

--- a/src/util/atov.hpp
+++ b/src/util/atov.hpp
@@ -1,10 +1,21 @@
 namespace atov {
-    std::vector<MPlug> convert(MPlugArray& plug_array)
+    std::vector<MPlug> convert(MPlugArray& array)
     {
-        std::vector<MPlug> result(plug_array.length());
+        std::vector<MPlug> result(array.length());
 
-        for (unsigned int i = 0; i < plug_array.length(); i++) {
-            result[i] = plug_array[i];
+        for (unsigned int i = 0; i < array.length(); i++) {
+            result[i] = array[i];
+        }
+
+        return result;
+    }
+
+    std::vector<std::string> convert(MStringArray& array)
+    {
+        std::vector<std::string> result(array.length());
+
+        for (unsigned int i = 0; i < array.length(); i++) {
+            result[i] = std::string(array[i].asChar());
         }
 
         return result;

--- a/src/util/atov.hpp
+++ b/src/util/atov.hpp
@@ -1,5 +1,5 @@
 namespace atov {
-    std::vector<int> convert(MIntArray& array)
+    inline std::vector<int> convert(MIntArray& array)
     {
         std::vector<int> result(array.length());
 
@@ -10,7 +10,7 @@ namespace atov {
         return result;
     }
 
-    std::vector<MPlug> convert(MPlugArray& array)
+    inline std::vector<MPlug> convert(MPlugArray& array)
     {
         std::vector<MPlug> result(array.length());
 
@@ -21,7 +21,7 @@ namespace atov {
         return result;
     }
 
-    std::vector<std::string> convert(MStringArray& array)
+    inline std::vector<std::string> convert(MStringArray& array)
     {
         std::vector<std::string> result(array.length());
 

--- a/src/util/atov.hpp
+++ b/src/util/atov.hpp
@@ -1,0 +1,12 @@
+namespace atov {
+    std::vector<MPlug> convert(MPlugArray& plug_array)
+    {
+        std::vector<MPlug> result(plug_array.length());
+
+        for (unsigned int i = 0; i < plug_array.length(); i++) {
+            result[i] = plug_array[i];
+        }
+
+        return result;
+    }
+}

--- a/src/util/atov.hpp
+++ b/src/util/atov.hpp
@@ -1,4 +1,15 @@
 namespace atov {
+    std::vector<int> convert(MIntArray& array)
+    {
+        std::vector<int> result(array.length());
+
+        for (unsigned int i = 0; i < array.length(); i++) {
+            result[i] = array[i];
+        }
+
+        return result;
+    }
+
     std::vector<MPlug> convert(MPlugArray& array)
     {
         std::vector<MPlug> result(array.length());

--- a/src/util/plug.hpp
+++ b/src/util/plug.hpp
@@ -1,0 +1,7 @@
+namespace plug {
+    inline void assert_not_null(MPlug &p) {
+        if (p.isNull()) {
+            throw std::invalid_argument("Accessed a null Plug.");
+        }
+    }
+}

--- a/src/util/plug.hpp
+++ b/src/util/plug.hpp
@@ -4,4 +4,40 @@ namespace plug {
             throw std::invalid_argument("Accessed a null Plug.");
         }
     }
+
+    inline void assert_is_array(MPlug &p) {
+        if (!p.isArray()) {
+            MString error_msg("Plug '^1s' is not an array plug.");
+                    error_msg.format(error_msg, p.name());
+
+            throw pybind11::type_error(error_msg.asChar());
+        }
+    }
+
+    inline void assert_is_not_array(MPlug &p) {
+        if (p.isArray()) {
+            MString error_msg("Plug '^1s' is an array plug.");
+                    error_msg.format(error_msg, p.name());
+
+            throw pybind11::type_error(error_msg.asChar());
+        }
+    }
+
+    inline void assert_is_compound(MPlug &p) {
+        if (!p.isCompound()) {
+            MString error_msg("Plug '^1s' is not a compound plug.");
+                    error_msg.format(error_msg, p.name());
+
+            throw pybind11::type_error(error_msg.asChar());
+        }
+    }
+
+    inline void assert_is_element(MPlug &p) {
+        if (!p.isElement()) {
+            MString error_msg("Plug '^1s' is not an array element plug.");
+                    error_msg.format(error_msg, p.name());
+
+            throw pybind11::type_error(error_msg.asChar());
+        }
+    }
 }

--- a/tests/test_MPlug.py
+++ b/tests/test_MPlug.py
@@ -26,6 +26,35 @@ def p(base, *args):
     return '.'.join(parts)
 
 
+class TestCommonMethods(unittest.TestCase):
+    """Tests for common MPlug methods bindings."""
+
+    node = None 
+
+    @classmethod 
+    def setUpClass(cls):
+        cmds.file(new=True, force=True)
+
+        node = cmds.createNode('network')
+
+        cmds.addAttr(node, ln='root', at='compound', nc=1)
+        cmds.addAttr(node, ln='branch', at='compound', nc=1, parent='root', multi=True)
+        cmds.addAttr(node, ln='leaf', parent='branch')
+        
+        cmds.setAttr(p(node, 'root', 'branch', 0, 'leaf'), 0.0)
+
+        cls.node = node 
+
+    def test_info(self):
+        """Test for MPlug::info binding."""
+
+        attr = p(self.node, 'root', 'branch', 0, 'leaf')
+        plug = cmdc.SelectionList().add(attr).getPlug(0)
+
+        # You would think it would return the full plug path, but it doesn't...
+        assert plug.info() == p(self.node, 'branch', 0, 'leaf')
+        
+
 class TestArrayMethods(unittest.TestCase):
     """Tests for MPlug methods bindings for array/element plugs."""
 

--- a/tests/test_MPlug.py
+++ b/tests/test_MPlug.py
@@ -27,6 +27,8 @@ def p(base, *args):
 
 
 class TestArrayMethods(unittest.TestCase):
+    """Tests for MPlug methods bindings for array/element plugs."""
+
     node = None 
 
     @classmethod 
@@ -45,6 +47,8 @@ class TestArrayMethods(unittest.TestCase):
         cls.node = node 
 
     def test_array(self):
+        """Test for MPlug::array binding."""
+        
         array_element = cmdc.SelectionList().add(p(self.node, 'array', 0)).getPlug(0)
         array_root = array_element.array()
 
@@ -57,6 +61,8 @@ class TestArrayMethods(unittest.TestCase):
         nose.tools.assert_raises(ValueError, cmdc.Plug().array)
 
     def test_numElements(self):
+        """Test for MPlug::numElements binding."""
+
         array_root = cmdc.SelectionList().add(p(self.node, 'array')).getPlug(0)
         
         assert array_root.numElements() == 3
@@ -68,6 +74,8 @@ class TestArrayMethods(unittest.TestCase):
 
 
 class TestCompoundPlugMethods(unittest.TestCase):
+    """Tests for MPlug methods bindings for compound plugs."""
+
     node = None
 
     @classmethod 
@@ -87,6 +95,8 @@ class TestCompoundPlugMethods(unittest.TestCase):
         cls.node = node 
 
     def test_child(self):
+        """Test for MPlug::child binding."""
+
         parent = cmdc.SelectionList().add(p(self.node, 'parent_a')).getPlug(0)
         child = cmdc.SelectionList().add(p(self.node, 'parent_a', 'child_a')).getPlug(0).attribute()
 
@@ -108,6 +118,8 @@ class TestCompoundPlugMethods(unittest.TestCase):
         nose.tools.assert_raises(ValueError, cmdc.Plug().child, 0)
 
     def test_parent(self):
+        """Test for MPlug::parent binding."""
+
         parent = cmdc.SelectionList().add(p(self.node, 'parent_a')).getPlug(0)
         child = cmdc.SelectionList().add(p(self.node, 'parent_a', 'child_a')).getPlug(0)
 
@@ -120,6 +132,8 @@ class TestCompoundPlugMethods(unittest.TestCase):
         nose.tools.assert_raises(ValueError, cmdc.Plug().parent)
 
     def test_numChildren(self):
+        """Test for MPlug::numChildren binding."""
+
         parent = cmdc.SelectionList().add(p(self.node, 'parent_a')).getPlug(0)
 
         assert parent.numChildren() == 1
@@ -131,6 +145,8 @@ class TestCompoundPlugMethods(unittest.TestCase):
 
 
 class TestConnectionMethods(unittest.TestCase):
+    """Tests for MPlug methods bindings for connections."""
+
     src_node = None 
     tgt_node = None 
 
@@ -148,6 +164,8 @@ class TestConnectionMethods(unittest.TestCase):
         cls.tgt_node = tgt_node
 
     def test_source(self):
+        """Test for MPlug::source binding."""
+
         src_plug = cmdc.SelectionList().add(p(self.src_node, 'attr')).getPlug(0)
         tgt_plug = cmdc.SelectionList().add(p(self.tgt_node, 'attr')).getPlug(0)
 
@@ -157,6 +175,8 @@ class TestConnectionMethods(unittest.TestCase):
         nose.tools.assert_raises(ValueError, cmdc.Plug().source)
 
     def test_sourceWithConversion(self):
+        """Test for MPlug::sourceWithConversion binding."""
+
         src_plug = cmdc.SelectionList().add(p(self.src_node, 'attr')).getPlug(0)
         tgt_plug = cmdc.SelectionList().add(p(self.tgt_node, 'attr')).getPlug(0)
 

--- a/tests/test_MPlug.py
+++ b/tests/test_MPlug.py
@@ -206,6 +206,29 @@ class TestConnectionMethods(unittest.TestCase):
         
         nose.tools.assert_raises(ValueError, cmdc.Plug().destinations)
 
+    def test_destinationsWithConversion(self):
+        """Test for MPlug::destinationsWithConversions binding."""
+
+        src_plug = cmdc.SelectionList().add(p(self.src_node, 'attr')).getPlug(0)
+        tgt_plug = cmdc.SelectionList().add(p(self.tgt_node, 'attr')).getPlug(0)
+        alt_plug = cmdc.SelectionList().add(p(self.alt_node, 'attr')).getPlug(0)
+
+        assert tgt_plug.destinations() == [], 'Plug.destinationsWithConversions should return an empty list for unconnected plugs'
+        
+        destinations = src_plug.destinationsWithConversions()
+        
+        assert destinations is not None, 'Plug.destinationsWithConversions returned a null'
+
+        assert len(destinations) == 2, 'Plug.destinationsWithConversions returned %s values; expected 2' % len(destinations)
+
+        assert destinations[0].node().hasFn(cmdc.Fn.kUnitConversion), 'Plug.destinationsWithConversions skipped over conversion node'
+        assert destinations[1].node().hasFn(cmdc.Fn.kUnitConversion), 'Plug.destinationsWithConversions skipped over conversion node'
+
+        assert tgt_plug not in destinations, 'Plug.destinationsWithConversions returned incorrect results'
+        assert alt_plug not in destinations, 'Plug.destinationsWithConversions returned incorrect results'
+        
+        nose.tools.assert_raises(ValueError, cmdc.Plug().destinationsWithConversions)
+
     def test_source(self):
         """Test for MPlug::source binding."""
 

--- a/tests/test_MPlug.py
+++ b/tests/test_MPlug.py
@@ -1,1 +1,47 @@
+"""Test suite for MPlug bindings."""
+
+import nose.tools
+
+from maya import cmds 
+
 import cmdc
+
+def test_plug_array_pass():
+    node = cmds.createNode('network')
+
+    cmds.addAttr(node, ln='test', multi=True)
+
+    attr_name = '{}.test'.format(node)
+    elem_name = '{}[0]'.format(attr_name)
+
+    cmds.setAttr(elem_name, 0.0)
+
+    array_element = cmdc.SelectionList().add(elem_name).getPlug(0)
+    array_root = array_element.array()
+
+    assert array_root is not None
+    assert array_root.name() == attr_name
+
+
+def test_plug_array_fails_on_non_array_plug():
+    node = cmds.createNode('network')
+
+    cmds.addAttr(node, ln='test')
+
+    attr_name = '{}.test'.format(node)
+
+    array_element = cmdc.SelectionList().add(attr_name).getPlug(0)
+
+    nose.tools.assert_raises(
+        TypeError,
+        array_element.array
+    )
+
+    
+def test_plug_array_fails_on_null_plug():
+    plug = cmdc.Plug()
+    
+    nose.tools.assert_raises(
+        ValueError,
+        plug.array
+    )

--- a/tests/test_MPlug.py
+++ b/tests/test_MPlug.py
@@ -102,3 +102,38 @@ class test_child(object):
         cmds.addAttr(node, ln='child_b', parent='parent_b')
 
         return node
+
+
+class test_source(object):
+    @staticmethod
+    def test_pass():
+        src_node = cmds.createNode('network', name='source')
+        tgt_node = cmds.createNode('network', name='target')
+
+        cmds.addAttr(src_node, ln='attr', at='double')
+        cmds.addAttr(tgt_node, ln='attr', at='doubleAngle')
+
+        cmds.connectAttr(src_node + '.attr', tgt_node + '.attr')
+
+        src_plug = cmdc.SelectionList().add(src_node + '.attr').getPlug(0)
+        tgt_plug = cmdc.SelectionList().add(tgt_node + '.attr').getPlug(0)
+
+        assert src_plug.source().isNull(), 'Plug.source should return a null plug when not a destination'
+        assert tgt_plug.source() == src_plug, 'Plug.source did not return the source plug.'
+
+    @staticmethod
+    def test_pass_with_conversion():
+        src_node = cmds.createNode('network', name='source')
+        tgt_node = cmds.createNode('network', name='target')
+
+        cmds.addAttr(src_node, ln='attr', at='double')
+        cmds.addAttr(tgt_node, ln='attr', at='doubleAngle')
+
+        cmds.connectAttr(src_node + '.attr', tgt_node + '.attr')
+
+        src_plug = cmdc.SelectionList().add(src_node + '.attr').getPlug(0)
+        tgt_plug = cmdc.SelectionList().add(tgt_node + '.attr').getPlug(0)
+
+        assert src_plug.sourceWithConversion().isNull(), 'Plug.sourceWithConversion should return a null plug when not a destination'
+        assert tgt_plug.sourceWithConversion() != src_plug, 'Plug.sourceWithConversion skipped over the conversion node'
+        assert tgt_plug.sourceWithConversion().node().hasFn(cmdc.Fn.kUnitConversion), 'Plug.sourceWithConversion skipped over conversion node'

--- a/tests/test_MPlug.py
+++ b/tests/test_MPlug.py
@@ -36,9 +36,11 @@ class TestArrayMethods(unittest.TestCase):
         node = cmds.createNode('network')
 
         cmds.addAttr(node, ln='array', multi=True)
-        cmds.addAttr(node, ln='single', multi=True)
+        cmds.addAttr(node, ln='single')
         
         cmds.setAttr(p(node, 'array', 0), 0.0)
+        cmds.setAttr(p(node, 'array', 1), 0.0)
+        cmds.setAttr(p(node, 'array', 3), 0.0)
 
         cls.node = node 
 
@@ -53,6 +55,16 @@ class TestArrayMethods(unittest.TestCase):
 
         nose.tools.assert_raises(TypeError, non_array_element.array)
         nose.tools.assert_raises(ValueError, cmdc.Plug().array)
+
+    def test_numElements(self):
+        array_root = cmdc.SelectionList().add(p(self.node, 'array')).getPlug(0)
+        
+        assert array_root.numElements() == 3
+
+        non_array_root = cmdc.SelectionList().add(p(self.node, 'single')).getPlug(0)
+
+        nose.tools.assert_raises(TypeError, non_array_root.numElements)
+        nose.tools.assert_raises(ValueError, cmdc.Plug().numElements)
 
 
 class TestCompoundPlugMethods(unittest.TestCase):

--- a/tests/test_MPlug.py
+++ b/tests/test_MPlug.py
@@ -42,17 +42,16 @@ class TestArrayMethods(unittest.TestCase):
 
         cls.node = node 
 
-    def test_array_pass(self):
+    def test_array(self):
         array_element = cmdc.SelectionList().add(p(self.node, 'array', 0)).getPlug(0)
         array_root = array_element.array()
 
         assert array_root is not None
         assert array_root.name() == p(self.node, 'array')
 
-    def test_array_fail(self):
-        array_element = cmdc.SelectionList().add(p(self.node, 'single')).getPlug(0)
+        non_array_element = cmdc.SelectionList().add(p(self.node, 'single')).getPlug(0)
 
-        nose.tools.assert_raises(TypeError, array_element.array)
+        nose.tools.assert_raises(TypeError, non_array_element.array)
         nose.tools.assert_raises(ValueError, cmdc.Plug().array)
 
 
@@ -75,7 +74,7 @@ class TestCompoundPlugMethods(unittest.TestCase):
 
         cls.node = node 
 
-    def test_child_pass(self):
+    def test_child(self):
         parent = cmdc.SelectionList().add(p(self.node, 'parent_a')).getPlug(0)
         child = cmdc.SelectionList().add(p(self.node, 'parent_a', 'child_a')).getPlug(0).attribute()
 
@@ -89,7 +88,6 @@ class TestCompoundPlugMethods(unittest.TestCase):
         assert attr is not None
         assert attr.name() == p(self.node, 'child_a'), attr.name()
 
-    def test_child_fail(self):
         parent = cmdc.SelectionList().add(p(self.node, 'parent_a')).getPlug(0)
         child = cmdc.SelectionList().add(p(self.node, 'parent_b', 'child_b')).getPlug(0).attribute()
 
@@ -97,12 +95,11 @@ class TestCompoundPlugMethods(unittest.TestCase):
         nose.tools.assert_raises(IndexError, parent.child, 1)
         nose.tools.assert_raises(ValueError, cmdc.Plug().child, 0)
 
-    def test_numChildren_pass(self):
+    def test_numChildren(self):
         parent = cmdc.SelectionList().add(p(self.node, 'parent_a')).getPlug(0)
 
         assert parent.numChildren() == 1
         
-    def test_numChildren_fail(self):
         non_parent = cmdc.SelectionList().add(p(self.node, 'single')).getPlug(0)
 
         nose.tools.assert_raises(TypeError, non_parent.numChildren)
@@ -126,7 +123,7 @@ class TestConnectionMethods(unittest.TestCase):
         cls.src_node = src_node
         cls.tgt_node = tgt_node
 
-    def test_source_pass(self):
+    def test_source(self):
         src_plug = cmdc.SelectionList().add(p(self.src_node, 'attr')).getPlug(0)
         tgt_plug = cmdc.SelectionList().add(p(self.tgt_node, 'attr')).getPlug(0)
 
@@ -135,7 +132,7 @@ class TestConnectionMethods(unittest.TestCase):
 
         nose.tools.assert_raises(ValueError, cmdc.Plug().source)
 
-    def test_sourceWithConversion_pass(self):
+    def test_sourceWithConversion(self):
         src_plug = cmdc.SelectionList().add(p(self.src_node, 'attr')).getPlug(0)
         tgt_plug = cmdc.SelectionList().add(p(self.tgt_node, 'attr')).getPlug(0)
 

--- a/tests/test_MPlug.py
+++ b/tests/test_MPlug.py
@@ -72,6 +72,20 @@ class TestArrayMethods(unittest.TestCase):
         nose.tools.assert_raises(TypeError, non_array_root.evaluateNumElements)
         nose.tools.assert_raises(ValueError, cmdc.Plug().evaluateNumElements)
 
+    def test_getExistingArrayAttributeIndices(self):
+        """Test for MPlug::getExistingArrayAttributeIndices binding."""
+
+        array_root = cmdc.SelectionList().add(p(self.node, 'array')).getPlug(0)
+        
+        indices = array_root.getExistingArrayAttributeIndices()
+
+        assert indices == [0, 1, 3]
+
+        non_array_root = cmdc.SelectionList().add(p(self.node, 'single')).getPlug(0)
+
+        nose.tools.assert_raises(TypeError, non_array_root.getExistingArrayAttributeIndices)
+        nose.tools.assert_raises(ValueError, cmdc.Plug().getExistingArrayAttributeIndices)
+
     def test_logicalIndex(self):
         """Test for MPlug::logicalIndex binding."""
 

--- a/tests/test_MPlug.py
+++ b/tests/test_MPlug.py
@@ -257,6 +257,33 @@ class TestConnectionMethods(unittest.TestCase):
         cls.tgt_node = tgt_node
         cls.alt_node = alt_node
 
+    def test_connectedTo(self):
+        """Test for MPlug::connectedTo binding."""
+
+        src_node = cmds.createNode('network')
+        the_node = cmds.createNode('network')
+        dst_node_a = cmds.createNode('network')
+        dst_node_b = cmds.createNode('network')
+
+        cmds.addAttr(src_node, ln='attr', at='double')
+        cmds.addAttr(the_node, ln='attr', at='double')
+        cmds.addAttr(dst_node_a, ln='attr', at='double')
+        cmds.addAttr(dst_node_b, ln='attr', at='double')
+
+        cmds.connectAttr(p(src_node, 'attr'), p(the_node, 'attr'))
+        cmds.connectAttr(p(the_node, 'attr'), p(dst_node_a, 'attr'))
+        cmds.connectAttr(p(the_node, 'attr'), p(dst_node_b, 'attr'))
+
+        the_plug = cmdc.SelectionList().add(p(the_node, 'attr')).getPlug(0)
+
+        src_connections = the_plug.connectedTo(True, True)
+        src_input = the_plug.connectedTo(True, False)
+        src_outputs = the_plug.connectedTo(False, True)
+
+        assert len(src_connections) == 3
+        assert len(src_input) == 1
+        assert len(src_outputs) == 2
+
     def test_destinations(self):
         """Test for MPlug::destinations binding."""
 

--- a/tests/test_MPlug.py
+++ b/tests/test_MPlug.py
@@ -60,6 +60,18 @@ class TestArrayMethods(unittest.TestCase):
         nose.tools.assert_raises(TypeError, non_array_element.array)
         nose.tools.assert_raises(ValueError, cmdc.Plug().array)
 
+    def test_evaluateNumElements(self):
+        """Test for MPlug::evaluateNumElements binding."""
+
+        array_root = cmdc.SelectionList().add(p(self.node, 'array')).getPlug(0)
+        
+        assert array_root.evaluateNumElements() == 3
+
+        non_array_root = cmdc.SelectionList().add(p(self.node, 'single')).getPlug(0)
+
+        nose.tools.assert_raises(TypeError, non_array_root.evaluateNumElements)
+        nose.tools.assert_raises(ValueError, cmdc.Plug().evaluateNumElements)
+
     def test_logicalIndex(self):
         """Test for MPlug::logicalIndex binding."""
 

--- a/tests/test_MPlug.py
+++ b/tests/test_MPlug.py
@@ -6,42 +6,44 @@ from maya import cmds
 
 import cmdc
 
-def test_plug_array_pass():
-    node = cmds.createNode('network')
+class test_array(object):
+    @staticmethod
+    def test_pass():
+        node = cmds.createNode('network')
 
-    cmds.addAttr(node, ln='test', multi=True)
+        cmds.addAttr(node, ln='test', multi=True)
 
-    attr_name = '{}.test'.format(node)
-    elem_name = '{}[0]'.format(attr_name)
+        attr_name = '{}.test'.format(node)
+        elem_name = '{}[0]'.format(attr_name)
 
-    cmds.setAttr(elem_name, 0.0)
+        cmds.setAttr(elem_name, 0.0)
 
-    array_element = cmdc.SelectionList().add(elem_name).getPlug(0)
-    array_root = array_element.array()
+        array_element = cmdc.SelectionList().add(elem_name).getPlug(0)
+        array_root = array_element.array()
 
-    assert array_root is not None
-    assert array_root.name() == attr_name
+        assert array_root is not None
+        assert array_root.name() == attr_name
 
+    @staticmethod
+    def test_fails_on_non_array_plug():
+        node = cmds.createNode('network')
 
-def test_plug_array_fails_on_non_array_plug():
-    node = cmds.createNode('network')
+        cmds.addAttr(node, ln='test')
 
-    cmds.addAttr(node, ln='test')
+        attr_name = '{}.test'.format(node)
 
-    attr_name = '{}.test'.format(node)
+        array_element = cmdc.SelectionList().add(attr_name).getPlug(0)
 
-    array_element = cmdc.SelectionList().add(attr_name).getPlug(0)
+        nose.tools.assert_raises(
+            TypeError,
+            array_element.array
+        )
 
-    nose.tools.assert_raises(
-        TypeError,
-        array_element.array
-    )
-
-    
-def test_plug_array_fails_on_null_plug():
-    plug = cmdc.Plug()
-    
-    nose.tools.assert_raises(
-        ValueError,
-        plug.array
-    )
+    @staticmethod
+    def test_fails_on_null_plug():
+        plug = cmdc.Plug()
+        
+        nose.tools.assert_raises(
+            ValueError,
+            plug.array
+        )

--- a/tests/test_MPlug.py
+++ b/tests/test_MPlug.py
@@ -52,10 +52,8 @@ class TestArrayMethods(unittest.TestCase):
     def test_array_fail(self):
         array_element = cmdc.SelectionList().add(p(self.node, 'single')).getPlug(0)
 
-        nose.tools.assert_raises(
-            TypeError,
-            array_element.array
-        )
+        nose.tools.assert_raises(TypeError, array_element.array)
+        nose.tools.assert_raises(ValueError, cmdc.Plug().array)
 
 
 class TestCompoundPlugMethods(unittest.TestCase):
@@ -72,6 +70,8 @@ class TestCompoundPlugMethods(unittest.TestCase):
 
         cmds.addAttr(node, ln='parent_b', at='compound', nc=1)
         cmds.addAttr(node, ln='child_b', parent='parent_b')
+
+        cmds.addAttr(node, ln='single')
 
         cls.node = node 
 
@@ -95,6 +95,18 @@ class TestCompoundPlugMethods(unittest.TestCase):
 
         nose.tools.assert_raises(ValueError, parent.child, child)
         nose.tools.assert_raises(IndexError, parent.child, 1)
+        nose.tools.assert_raises(ValueError, cmdc.Plug().child, 0)
+
+    def test_numChildren_pass(self):
+        parent = cmdc.SelectionList().add(p(self.node, 'parent_a')).getPlug(0)
+
+        assert parent.numChildren() == 1
+        
+    def test_numChildren_fail(self):
+        non_parent = cmdc.SelectionList().add(p(self.node, 'single')).getPlug(0)
+
+        nose.tools.assert_raises(TypeError, non_parent.numChildren)
+        nose.tools.assert_raises(ValueError, cmdc.Plug().numChildren)
 
 
 class TestConnectionMethods(unittest.TestCase):
@@ -121,6 +133,8 @@ class TestConnectionMethods(unittest.TestCase):
         assert src_plug.source().isNull(), 'Plug.source should return a null plug when not a destination'
         assert tgt_plug.source() == src_plug, 'Plug.source did not return the source plug.'
 
+        nose.tools.assert_raises(ValueError, cmdc.Plug().source)
+
     def test_sourceWithConversion_pass(self):
         src_plug = cmdc.SelectionList().add(p(self.src_node, 'attr')).getPlug(0)
         tgt_plug = cmdc.SelectionList().add(p(self.tgt_node, 'attr')).getPlug(0)
@@ -128,3 +142,5 @@ class TestConnectionMethods(unittest.TestCase):
         assert src_plug.sourceWithConversion().isNull(), 'Plug.sourceWithConversion should return a null plug when not a destination'
         assert tgt_plug.sourceWithConversion() != src_plug, 'Plug.sourceWithConversion skipped over the conversion node'
         assert tgt_plug.sourceWithConversion().node().hasFn(cmdc.Fn.kUnitConversion), 'Plug.sourceWithConversion skipped over conversion node'
+
+        nose.tools.assert_raises(ValueError, cmdc.Plug().sourceWithConversion)

--- a/tests/test_MPlug.py
+++ b/tests/test_MPlug.py
@@ -53,21 +53,46 @@ class test_array(object):
 class test_child(object):
     @staticmethod
     def test_pass_attr():
-        node = cmds.createNode('network')
+        node = test_child._setup_scene()
 
-        cmds.addAttr(node, ln='test', at='compound', nc=1)
-        cmds.addAttr(node, ln='child', parent='test')
-        
-        parent = cmdc.SelectionList().add(node + '.test').getPlug(0)
-        child = cmdc.SelectionList().add(node + '.test.child').getPlug(0).attribute()
+        parent = cmdc.SelectionList().add(node + '.parent_a').getPlug(0)
+        child = cmdc.SelectionList().add(node + '.parent_a.child_a').getPlug(0).attribute()
 
         attr = parent.child(child)
 
         assert attr is not None
-        assert attr.name() == node + '.child', attr.name()
+        assert attr.name() == node + '.child_a', attr.name()
 
     @staticmethod
     def test_fail_attr():
+        node = test_child._setup_scene()
+
+        parent = cmdc.SelectionList().add(node + '.parent_a').getPlug(0)
+        child = cmdc.SelectionList().add(node + '.parent_b.child_b').getPlug(0).attribute()
+
+        nose.tools.assert_raises(ValueError, parent.child, child)
+
+    @staticmethod
+    def test_pass_index():
+        node = test_child._setup_scene()
+        
+        parent = cmdc.SelectionList().add(node + '.parent_a').getPlug(0)
+
+        attr = parent.child(0)
+
+        assert attr is not None
+        assert attr.name() == node + '.child_a', attr.name()
+
+    @staticmethod
+    def test_fail_index():
+        node = test_child._setup_scene()
+
+        parent = cmdc.SelectionList().add(node + '.parent_a').getPlug(0)
+
+        nose.tools.assert_raises(IndexError, parent.child, 1)
+
+    @staticmethod
+    def _setup_scene():
         node = cmds.createNode('network')
 
         cmds.addAttr(node, ln='parent_a', at='compound', nc=1)
@@ -76,7 +101,4 @@ class test_child(object):
         cmds.addAttr(node, ln='parent_b', at='compound', nc=1)
         cmds.addAttr(node, ln='child_b', parent='parent_b')
 
-        parent_a = cmdc.SelectionList().add(node + '.parent_a').getPlug(0)
-        child_b = cmdc.SelectionList().add(node + '.parent_b.child_b').getPlug(0).attribute()
-
-        nose.tools.assert_raises(ValueError, parent_a.child, child_b)
+        return node

--- a/tests/test_MPlug.py
+++ b/tests/test_MPlug.py
@@ -60,6 +60,24 @@ class TestArrayMethods(unittest.TestCase):
         nose.tools.assert_raises(TypeError, non_array_element.array)
         nose.tools.assert_raises(ValueError, cmdc.Plug().array)
 
+    def test_logicalIndex(self):
+        """Test for MPlug::logicalIndex binding."""
+
+        selection = cmdc.SelectionList().add(p(self.node, 'array[*]'))
+
+        plug_0 = selection.getPlug(0)
+        plug_1 = selection.getPlug(1)
+        plug_3 = selection.getPlug(2)
+
+        assert plug_0.logicalIndex() == 0
+        assert plug_1.logicalIndex() == 1
+        assert plug_3.logicalIndex() == 3
+
+        non_element = cmdc.SelectionList().add(p(self.node, 'single')).getPlug(0)
+
+        nose.tools.assert_raises(TypeError, non_element.logicalIndex)
+        nose.tools.assert_raises(ValueError, cmdc.Plug().logicalIndex)
+
     def test_numElements(self):
         """Test for MPlug::numElements binding."""
 

--- a/tests/test_MPlug.py
+++ b/tests/test_MPlug.py
@@ -25,7 +25,7 @@ class test_array(object):
         assert array_root.name() == attr_name
 
     @staticmethod
-    def test_fails_on_non_array_plug():
+    def test_fail():
         node = cmds.createNode('network')
 
         cmds.addAttr(node, ln='test')
@@ -40,10 +40,33 @@ class test_array(object):
         )
 
     @staticmethod
-    def test_fails_on_null_plug():
+    def test_null():
         plug = cmdc.Plug()
-        
+
         nose.tools.assert_raises(
             ValueError,
             plug.array
+        )
+
+class test_attribute(object):
+    @staticmethod
+    def test_pass():
+        node = cmds.createNode('network')
+
+        cmds.addAttr(node, ln='test')
+        attr_name = '{}.test'.format(node)
+
+        plug = cmdc.SelectionList().add(attr_name).getPlug(0)
+        attr = plug.attribute()
+
+        assert attr is not None
+        assert attr.hasFn(cmdc.Fn.kAttribute)
+
+    @staticmethod
+    def test_null():
+        plug = cmdc.Plug()
+
+        nose.tools.assert_raises(
+            ValueError,
+            plug.attribute
         )

--- a/tests/test_MPlug.py
+++ b/tests/test_MPlug.py
@@ -1,0 +1,1 @@
+import cmdc

--- a/tests/test_MPlug.py
+++ b/tests/test_MPlug.py
@@ -107,6 +107,18 @@ class TestCompoundPlugMethods(unittest.TestCase):
         nose.tools.assert_raises(IndexError, parent.child, 1)
         nose.tools.assert_raises(ValueError, cmdc.Plug().child, 0)
 
+    def test_parent(self):
+        parent = cmdc.SelectionList().add(p(self.node, 'parent_a')).getPlug(0)
+        child = cmdc.SelectionList().add(p(self.node, 'parent_a', 'child_a')).getPlug(0)
+
+        result = child.parent()
+
+        assert result is not None
+        assert result.name() == parent.name()
+
+        nose.tools.assert_raises(TypeError, parent.parent)
+        nose.tools.assert_raises(ValueError, cmdc.Plug().parent)
+
     def test_numChildren(self):
         parent = cmdc.SelectionList().add(p(self.node, 'parent_a')).getPlug(0)
 

--- a/tests/test_MPlug.py
+++ b/tests/test_MPlug.py
@@ -60,6 +60,51 @@ class TestArrayMethods(unittest.TestCase):
         nose.tools.assert_raises(TypeError, non_array_element.array)
         nose.tools.assert_raises(ValueError, cmdc.Plug().array)
 
+    def test_elementByLogicalIndex(self):
+        """Test for MPlug::elementByLogicalIndex binding."""
+
+        array_root = cmdc.SelectionList().add(p(self.node, 'array')).getPlug(0)
+        
+        selection = cmdc.SelectionList().add(p(self.node, 'array[*]'))
+
+        plug_0 = selection.getPlug(0)
+        plug_1 = selection.getPlug(1)
+        plug_3 = selection.getPlug(2)
+
+        assert array_root.elementByLogicalIndex(0) == plug_0
+        assert array_root.elementByLogicalIndex(1) == plug_1
+        assert array_root.elementByLogicalIndex(3) == plug_3
+
+        # A plug will be created at the requested index if it does not exist.
+        assert not array_root.elementByLogicalIndex(5).isNull()
+
+        non_array_root = cmdc.SelectionList().add(p(self.node, 'single')).getPlug(0)
+
+        nose.tools.assert_raises(TypeError, non_array_root.elementByLogicalIndex, 0)
+        nose.tools.assert_raises(ValueError, cmdc.Plug().elementByLogicalIndex, 0)
+
+    def test_elementByPhysicalIndex(self):
+        """Test for MPlug::elementByPhysicalIndex binding."""
+
+        array_root = cmdc.SelectionList().add(p(self.node, 'array')).getPlug(0)
+        
+        selection = cmdc.SelectionList().add(p(self.node, 'array[*]'))
+
+        plug_0 = selection.getPlug(0)
+        plug_1 = selection.getPlug(1)
+        plug_3 = selection.getPlug(2)
+
+        assert array_root.elementByPhysicalIndex(0) == plug_0
+        assert array_root.elementByPhysicalIndex(1) == plug_1
+        assert array_root.elementByPhysicalIndex(2) == plug_3
+
+        nose.tools.assert_raises(IndexError, array_root.elementByPhysicalIndex, 9001)
+
+        non_array_root = cmdc.SelectionList().add(p(self.node, 'single')).getPlug(0)
+
+        nose.tools.assert_raises(TypeError, non_array_root.elementByPhysicalIndex, 0)
+        nose.tools.assert_raises(ValueError, cmdc.Plug().elementByPhysicalIndex, 0)
+    
     def test_evaluateNumElements(self):
         """Test for MPlug::evaluateNumElements binding."""
 


### PR DESCRIPTION
### Added
 - Implement most `MPlug` methods; the getter/setter methods and a few one off methods still need to be added
 - Implement tests for `MPlug` methods; grouped by functionality to minimize repetitive setup/teardown
 - Add helper functions for converting M*Array -> std::vector<T>.
 - Add helper functions for repetitive MPlug instance validations

### wat 
 - `MPlug::child(MObject attribute, MStatus status)` did not behave as expected. I'm not sure if this is a bug in the C++ itself or if I just made a subtle error. Either way, I went with a brute force search.