### PR TITLE
Add mayapy

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -95,22 +95,30 @@ jobs:
 
       matrix:
        include:
-         - maya: "2018.7"
+         - maya: "2018.7" # For distribution
+           image: "2018"  # For docker
+           pip: "2.7/get-pip.py"
            devkit: "https://autodesk-adn-transfer.s3.us-west-2.amazonaws.com/ADN%20Extranet/M%26E/Maya/devkit%202018/Autodesk_Maya_2018_7_Update_DEVKIT_Linux.tgz"
          - maya: "2019.3"
+           image: "2019"
+           pip: "2.7/get-pip.py"
            devkit: "https://autodesk-adn-transfer.s3.us-west-2.amazonaws.com/ADN%20Extranet/M%26E/Maya/devkit%202019/Autodesk_Maya_2019_3_Update_DEVKIT_Linux.tgz"
          - maya: "2020.4"
+           image: "2020"
+           pip: "2.7/get-pip.py"
            devkit: "https://autodesk-adn-transfer.s3.us-west-2.amazonaws.com/ADN%20Extranet/M%26E/Maya/devkit%202020/Autodesk_Maya_2020_4_Update_DEVKIT_Linux.tgz"
          - maya: "2022"
+           image: "2022"
+           pip: "get-pip.py"
            devkit: "https://autodesk-adn-transfer.s3.us-west-2.amazonaws.com/ADN%20Extranet/M%26E/Maya/devkit%202022/Autodesk_Maya_2022_DEVKIT_Linux.tgz"
 
-    container: mottosso/mayabase-centos7
+    container: mottosso/maya:${{ matrix.image }}
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v1
 
-      - name: Setup Compiler Environment
+      - name: Setup Build Environment
         run: |
           yum install centos-release-scl -y
           yum install devtoolset-7 bc -y
@@ -131,6 +139,35 @@ jobs:
           g++ --version
           chmod +x ./build_linux.sh
           ./build_linux.sh ${{ matrix.maya }}
+
+      # We'll lock each version to one that works with both Python 2.7 and 3.7
+      - name: Setup Test Environment
+        run: |
+          wget https://bootstrap.pypa.io/pip/${{ matrix.pip }}
+          mayapy get-pip.py --user
+          mayapy -m pip install --user \
+            nose==1.3.7 \
+            nose-exclude==0.5.0 \
+            coverage==5.5 \
+            flaky==3.7.0 \
+            sphinx==1.8.5 \
+            sphinxcontrib-napoleon==0.7
+
+        # Since 2019, this sucker throws an unnecessary
+        # warning if not declared.
+      - name: Environment
+        run: |
+          mkdir -p /var/tmp/runtime-root
+          export XDG_RUNTIME_DIR=/var/tmp/runtime-root
+          export MAYA_DISABLE_ADP=1
+
+      - name: Testests
+        run: |
+          pwd
+          ls
+          mayapy --version
+          export PYTHONPATH=$(pwd)/build
+          mayapy -m nose -xv --exe ./tests
 
       - name: Artifacts
         uses: actions/upload-artifact@v2

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.pyd
 build/**
 tmp/*
+*.pyc

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,13 +1,13 @@
-import atexit
+from maya import standalone, cmds
 
-import maya.standalone 
-from maya import cmds
 
 def setup():
-    maya.standalone.initialize()
+    standalone.initialize()
+
 
 def new_scene():
     cmds.file(new=True, force=True)
 
+
 def teardown():
-    maya.standalone.uninitialize()
+    standalone.uninitialize()


### PR DESCRIPTION
Builds now run with access to mayapy, on Linux. Now we can run tests and do other things that require mayapy, like #16 