### PR TITLE
Improve stubs part two

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,15 +57,12 @@ print("Success")
 
 Code completion working in Visual Studio Code with Pylance:
 
-<video autoplay muted loop>
-  <source src="https://user-images.githubusercontent.com/3117205/121938610-50b24100-cd4c-11eb-9325-28c35e00f4d7.mp4" type="video/mp4">
-</video>
+![cmdc_completion](https://user-images.githubusercontent.com/3117205/121947966-f7034400-cd56-11eb-85ad-5b1d9aac091d.gif)
+
 
 Type Checking working in Visual Studio Code with Pylance:
 
-<video autoplay muted loop>
-  <source src="https://user-images.githubusercontent.com/3117205/121938616-53ad3180-cd4c-11eb-9b5d-d2f7e7829b82.mp4" type="video/mp4">
-</video>
+![cmdc_type_checking](https://user-images.githubusercontent.com/3117205/121947972-f8347100-cd56-11eb-8782-3d5fcd6c4376.gif)
 
 <br>
 

--- a/README.md
+++ b/README.md
@@ -57,11 +57,15 @@ print("Success")
 
 Code completion working in Visual Studio Code with Pylance:
 
-https://user-images.githubusercontent.com/3117205/121938610-50b24100-cd4c-11eb-9325-28c35e00f4d7.mp4
+<video autoplay muted loop>
+  <source src="https://user-images.githubusercontent.com/3117205/121938610-50b24100-cd4c-11eb-9325-28c35e00f4d7.mp4" type="video/mp4">
+</video>
 
 Type Checking working in Visual Studio Code with Pylance:
 
-https://user-images.githubusercontent.com/3117205/121938610-50b24100-cd4c-11eb-9325-28c35e00f4d7.mp4
+<video autoplay muted loop>
+  <source src="https://user-images.githubusercontent.com/3117205/121938616-53ad3180-cd4c-11eb-9b5d-d2f7e7829b82.mp4" type="video/mp4">
+</video>
 
 <br>
 

--- a/README.md
+++ b/README.md
@@ -55,14 +55,13 @@ print(fn.name())
 print("Success")
 ```
 
-Code completion working in Visual Studio Code with Pylance:
+**Code completion working in Visual Studio Code with Pylance**
 
-![cmdc_completion](https://user-images.githubusercontent.com/3117205/121947966-f7034400-cd56-11eb-85ad-5b1d9aac091d.gif)
+<img width=500 src=https://user-images.githubusercontent.com/3117205/121947966-f7034400-cd56-11eb-85ad-5b1d9aac091d.gif>
 
+**Type Checking working in Visual Studio Code with Pylance**
 
-Type Checking working in Visual Studio Code with Pylance:
-
-![cmdc_type_checking](https://user-images.githubusercontent.com/3117205/121947972-f8347100-cd56-11eb-8782-3d5fcd6c4376.gif)
+<img width=500 src=https://user-images.githubusercontent.com/3117205/121947972-f8347100-cd56-11eb-8782-3d5fcd6c4376.gif>
 
 <br>
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ An alternative set of bindings for the C++ API of Maya 2018-2022.
 - What if you could address bugs in the bindings yourself?
 - What if you could *add* missing members yourself?
 - What if there were bindings for Maya that made it impossible to crash Maya from Python?
+- What if setting up code completion and type checking was easy?
 
 That's what this repository is for.
 
@@ -54,6 +55,14 @@ print(fn.name())
 print("Success")
 ```
 
+Code completion working in Visual Studio Code with Pylance:
+
+https://user-images.githubusercontent.com/3117205/121938610-50b24100-cd4c-11eb-9325-28c35e00f4d7.mp4
+
+Type Checking working in Visual Studio Code with Pylance:
+
+https://user-images.githubusercontent.com/3117205/121938610-50b24100-cd4c-11eb-9325-28c35e00f4d7.mp4
+
 <br>
 
 ### Goal
@@ -67,8 +76,8 @@ print("Success")
 - Object attributes are preferred over rather than set/get methods. For example you can now write array.sizeIncrement=64.
 - There are more types of exceptions used when methods fail. Not everything is a RuntimeError, as was the case in the old API.
 - `cmdc` should be faster or as fast as API 2.0
-
-> [Reference](https://help.autodesk.com/view/MAYAUL/2020/ENU/?guid=__py_ref_index_html)
+  > [Reference](https://help.autodesk.com/view/MAYAUL/2020/ENU/?guid=__py_ref_index_html)
+- `cmdc` comes with fully type annotated stubs, making it easy to set up code completion as well as type checking.
 
 <br>
 

--- a/scripts/generate_stubs.py
+++ b/scripts/generate_stubs.py
@@ -1,10 +1,16 @@
-import cmdc
-
 import inspect
-import pybind11_stubgen
+import sys
 import time
 
+import cmdc
+import pybind11_stubgen
+
 STUBS_LOCATION = "build/cmdc.pyi"
+
+
+class InvalidSignatureError(Exception):
+    """Raised when one or more signatures are invalid."""
+
 
 def cleanup_imports(content):
     """Remove any classes accidentally imported as modules.
@@ -29,36 +35,48 @@ def cleanup_imports(content):
 
     return content
 
-print("Generating stubs")
-t0 = time.time()
 
-module = pybind11_stubgen.ModuleStubsGenerator(cmdc)
-module.write_setup_py = False
+def main():
+    print("Generating stubs")
+    t0 = time.time()
 
-print("(1) Parsing module..")
+    module = pybind11_stubgen.ModuleStubsGenerator(cmdc)
+    module.write_setup_py = False
 
-module.parse()
+    print("(1) Parsing module..")
 
-t1 = time.time()
-print("(1) Finished in {0:0.3} s".format(t1-t0))
-print("(1) ----------------------------")
+    module.parse()
 
-print("(2) Generating stubs content..")
+    invalid_signatures_count = pybind11_stubgen.FunctionSignature.n_invalid_signatures
+    if invalid_signatures_count > 0:
+        raise InvalidSignatureError(
+            f"Module contains {invalid_signatures_count} invalid signature(s)"
+        )
 
-content = "\n".join(module.to_lines())
-content = cleanup_imports(content)
+    t1 = time.time()
+    print("(1) Finished in {0:0.3} s".format(t1 - t0))
+    print("(1) ----------------------------")
 
-t2 = time.time()
-print("(2) Finished in {0:0.3} s".format(t2-t1))
-print("(2) ----------------------------")
-print("(3) Writing stubs file..")
+    print("(2) Generating stubs content..")
 
-with open(STUBS_LOCATION, "w") as handle:
-    handle.write(content)
+    content = "\n".join(module.to_lines())
+    content = cleanup_imports(content)
 
-t3 = time.time()
-print("(3) Finished in {0:0.3} s".format(t3-t2))
-print("(3) ----------------------------")
+    t2 = time.time()
+    print(f"(2) Finished in {t2 - t1:0.3} s")
+    print("f(2) ----------------------------")
 
-print("Succesfully created .{0} in {1:0.3} s".format(STUBS_LOCATION, t3-t0))
+    print("(3) Writing stubs file..")
 
+    with open(STUBS_LOCATION, "w") as handle:
+        handle.write(content)
+
+    t3 = time.time()
+    print(f"(3) Finished in {t3 - t2:0.3} s")
+    print("(3) ----------------------------")
+
+    print(f"Succesfully created .{STUBS_LOCATION} in {t3 - t0:0.3} s")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/generate_stubs.py
+++ b/scripts/generate_stubs.py
@@ -1,12 +1,38 @@
-import time
+import cmdc
+
+import inspect
 import pybind11_stubgen
+import time
 
 STUBS_LOCATION = "build/cmdc.pyi"
+
+def cleanup_imports(content):
+    """Remove any classes accidentally imported as modules.
+
+    This is a fix for this bug:
+    https://github.com/sizmailov/pybind11-stubgen/issues/36
+    Some classes with nested classes get imported when they shouldn't, breaking
+    leaving them breaks autocomplete
+    """
+
+    classes = []
+    for name, obj in inspect.getmembers(cmdc, inspect.isclass):
+        classes.append(name)
+
+        # also include any class that might be defined inside of another class.
+        # these are actually the ones that are causing issues.
+        for sub_name, _ in inspect.getmembers(obj, inspect.isclass):
+            classes.append(sub_name)
+
+    for class_name in classes:
+        content = content.replace("import {}\n".format(class_name), "")
+
+    return content
 
 print("Generating stubs")
 t0 = time.time()
 
-module = pybind11_stubgen.ModuleStubsGenerator("cmdc")
+module = pybind11_stubgen.ModuleStubsGenerator(cmdc)
 module.write_setup_py = False
 
 print("(1) Parsing module..")
@@ -17,16 +43,22 @@ t1 = time.time()
 print("(1) Finished in {0:0.3} s".format(t1-t0))
 print("(1) ----------------------------")
 
-print("(2) Writing stubs..")
+print("(2) Generating stubs content..")
 
-with open(STUBS_LOCATION, "w") as handle:
-    content = "\n".join(module.to_lines())
-
-    handle.write(content)
+content = "\n".join(module.to_lines())
+content = cleanup_imports(content)
 
 t2 = time.time()
 print("(2) Finished in {0:0.3} s".format(t2-t1))
 print("(2) ----------------------------")
+print("(3) Writing stubs file..")
 
-print("Succesfully created .{0} in {1:0.3} s".format(STUBS_LOCATION, t2-t0))
+with open(STUBS_LOCATION, "w") as handle:
+    handle.write(content)
+
+t3 = time.time()
+print("(3) Finished in {0:0.3} s".format(t3-t2))
+print("(3) ----------------------------")
+
+print("Succesfully created .{0} in {1:0.3} s".format(STUBS_LOCATION, t3-t0))
 

--- a/src/MDagModifier.inl
+++ b/src/MDagModifier.inl
@@ -1,3 +1,30 @@
+#define _doc_DagModifier_createNode \
+    "Adds an operation to the modifier to create a DAG node of the\n"\
+    "specified type.\n"\
+    "\n"\
+    "If a parent DAG node is provided the new node will be parented\n"\
+    "under it.\n"\
+    "If no parent is provided and the new DAG node is a transform type then\n"\
+    "it will be parented under the world.\n"\
+    "In both of these cases the method returns the new DAG node.\n"\
+    "\n"\
+    "If no parent is provided and the new DAG node is not a transform type\n"\
+    "then a transform node will be created and the child parented under that.\n"\
+    "The new transform will be parented under the world and it is\n"\
+    "the transform node which will be returned by the method, not the child.\n"\
+    "\n"\
+    "None of the newly created nodes will be added to the DAG until\n"\
+    "the modifier's doIt() method is called.\n"\
+
+#define _doc_DagModifier_reparentNode \
+    "Adds an operation to the modifier to reparent a DAG node under\n"\
+    "a specified parent.\n"\
+    "\n"\
+    "If no parent is provided then the DAG node will be reparented under\n"\
+    "the world, so long as it is a transform type.\n"\
+    "If it is not a transform type then the doIt() will raise a RuntimeError."
+
+
 #include "MDGModifier.inl"
 
 py::class_<MDagModifier, MDGModifier>(m, "DagModifier")
@@ -30,18 +57,9 @@ py::class_<MDagModifier, MDGModifier>(m, "DagModifier")
         CHECK_STATUS(status)
 
         return result;
-    }, 
-R"pbdoc(Adds an operation to the modifier to create a DAG node of the specified type. 
-If a parent DAG node is provided the new node will be parented under it. 
-If no parent is provided and the new DAG node is a transform type then it will be parented under the world. 
-In both of these cases, the method returns the new DAG node.
-
-If no parent is provided and the new DAG node is not a transform type 
-then a transform node will be created and the child parented under that. 
-The new transform will be parented under the world \
-and it is the transform node which will be returned by the method, not the child.
-
-None of the newly created nodes will be added to the DAG until the modifier's doIt() method is called.)pbdoc")
+    }, py::arg("type"),
+       py::arg_v("parent", MObject::kNullObj, "Object.kNullObj"),
+       _doc_DagModifier_createNode)
 
     .def("createNode", [](MDagModifier & self, MTypeId typeId, MObject parent = MObject::kNullObj) -> MObject {
         if (!parent.isNull())
@@ -71,19 +89,9 @@ None of the newly created nodes will be added to the DAG until the modifier's do
         CHECK_STATUS(status)
 
         return result;
-    },
-R"pbdoc(Adds an operation to the modifier to create a DAG node of the specified type. 
-    
-If a parent DAG node is provided the new node will be parented under it. 
-If no parent is provided and the new DAG node is a transform type then it will be parented under the world. 
-In both of these cases the method returns the new DAG node.
-
-If no parent is provided and the new DAG node is not a transform type 
-then a transform node will be created and the child parented under that. 
-The new transform will be parented under the world \ 
-and it is the transform node which will be returned by the method, not the child.
-
-None of the newly created nodes will be added to the DAG until the modifier's doIt() method is called.)pbdoc")
+    }, py::arg("typeId"),
+       py::arg_v("parent", MObject::kNullObj, "Object.kNullObj"),
+       _doc_DagModifier_createNode)
 
     .def("reparentNode", [](MDagModifier & self, MObject node, MObject newParent = MObject::kNullObj) {
         validate::is_not_null(node, "Cannot reparent a null object.");
@@ -140,8 +148,6 @@ None of the newly created nodes will be added to the DAG until the modifier's do
         MStatus status = self.reparentNode(node, newParent);
 
         CHECK_STATUS(status)
-    }, 
-R"pbdoc(Adds an operation to the modifier to reparent a DAG node under a specified parent.
-
-If no parent is provided then the DAG node will be reparented under the world, so long as it is a transform type. 
-If it is not a transform type then the doIt() will raise a RuntimeError.)pbdoc");
+    }, py::arg("node"),
+       py::arg_v("newParent", MObject::kNullObj, "Object.kNullObj"),
+       _doc_DagModifier_reparentNode);


### PR DESCRIPTION
So, when trying to record the gif for the readme, I realized the completion wasn't working on some classes like `SelectionList`.
Turns out pybind11-stubgen gets a bit confused when a class has an inner class defined and tries to import the parent class as a module. This is tracked by this issue: https://github.com/sizmailov/pybind11-stubgen/issues/36

I've opted to just remove the unwanted imports once the stubs are generated, might be a bit brute force but that felt like the only option that didn't cause other issues somewhere else in the stubs.

I'll also update the readme and contributing.md as part of this PR.
@mottosso is there a good place where I can store the gif?