### PR TITLE
Better stubs generation errors and debugging

### DIFF
--- a/scripts/generate_stubs.py
+++ b/scripts/generate_stubs.py
@@ -15,30 +15,6 @@ class UnnamedArgumentError(Exception):
     """Raised when one or more signatures contain unnamed arguments."""
 
 
-def cleanup_imports(content):
-    """Remove any classes accidentally imported as modules.
-
-    This is a fix for this bug:
-    https://github.com/sizmailov/pybind11-stubgen/issues/36
-    Some classes with nested classes get imported when they shouldn't, breaking
-    leaving them breaks autocomplete
-    """
-
-    classes = []
-    for name, obj in inspect.getmembers(cmdc, inspect.isclass):
-        classes.append(name)
-
-        # also include any class that might be defined inside of another class.
-        # these are actually the ones that are causing issues.
-        for sub_name, _ in inspect.getmembers(obj, inspect.isclass):
-            classes.append(sub_name)
-
-    for class_name in classes:
-        content = content.replace("import {}\n".format(class_name), "")
-
-    return content
-
-
 def count_unnamed_args(lines):
     """Count all the signatures that have unnamed arguments.
 
@@ -90,9 +66,6 @@ def main(outStubFile, *args):
         raise UnnamedArgumentError(
             f"Module contains {unnamed_args_count} signatures with unnamed arguments."
         )
-
-    content = "\n".join(module.to_lines())
-    content = cleanup_imports(content)
 
     t2 = time.time()
     print(f"(2) Finished in {t2 - t1:0.3} s")

--- a/scripts/generate_stubs.py
+++ b/scripts/generate_stubs.py
@@ -13,28 +13,26 @@ class UnnamedArgumentError(Exception):
     """Raised when one or more signatures contain unnamed arguments."""
 
 
-def count_unnamed_args(lines):
+def count_unnamed_args(content):
     """Count all the signatures that have unnamed arguments.
 
     This ignores property setters as these will always have unnamed arguments.
     """
+    lines = content.split("\n")
 
     unnamed_signatures = []
-    for line in lines:
+
+    previous_line = ""
+    for i, line in enumerate(lines):
         if "arg0" in line and "setter" not in previous_line:
+            print(f"Invalid signature line {i + 1}: {line.strip(' ')}")
             unnamed_signatures.append(line)
         previous_line = line
-
-    if unnamed_signatures:
-        print("These signatures contain unnamed arguments:")
-        for signature in unnamed_signatures:
-            print(f"    {signature.strip(' ')}")
 
     return len(unnamed_signatures)
 
 
 def main(outStubFile, *args):
-
     print("Generating stubs")
     t0 = time.time()
 
@@ -62,8 +60,8 @@ def main(outStubFile, *args):
 
     print("(2) Generating stubs content..")
 
-    lines = module.to_lines()
-    unnamed_args_count = count_unnamed_args(lines)
+    content = "\n".join(module.to_lines())
+    unnamed_args_count = count_unnamed_args(content)
 
     if unnamed_args_count > 0 and raise_on_invalid_stub:
         raise UnnamedArgumentError(

--- a/scripts/generate_stubs.py
+++ b/scripts/generate_stubs.py
@@ -1,5 +1,3 @@
-import inspect
-from itertools import count
 import sys
 import time
 
@@ -40,6 +38,10 @@ def main(outStubFile, *args):
     print("Generating stubs")
     t0 = time.time()
 
+    raise_on_invalid_stub = True
+    if "--no-raise" in args:
+        raise_on_invalid_stub = False
+
     module = pybind11_stubgen.ModuleStubsGenerator(cmdc)
     module.write_setup_py = False
 
@@ -48,9 +50,10 @@ def main(outStubFile, *args):
     module.parse()
 
     invalid_signatures_count = pybind11_stubgen.FunctionSignature.n_invalid_signatures
-    if invalid_signatures_count > 0:
+    if invalid_signatures_count > 0 and raise_on_invalid_stub:
         raise InvalidSignatureError(
-            f"Module contains {invalid_signatures_count} invalid signature(s)"
+            f"Module contains {invalid_signatures_count} invalid signature(s). "
+            "Use `--no-raise` if you want to generate the stubs anyway."
         )
 
     t1 = time.time()
@@ -62,9 +65,10 @@ def main(outStubFile, *args):
     lines = module.to_lines()
     unnamed_args_count = count_unnamed_args(lines)
 
-    if unnamed_args_count > 0:
+    if unnamed_args_count > 0 and raise_on_invalid_stub:
         raise UnnamedArgumentError(
-            f"Module contains {unnamed_args_count} signatures with unnamed arguments."
+            f"Module contains {unnamed_args_count} signatures with unnamed arguments. "
+            "Use `--no-raise` if you want to generate the stubs anyway."
         )
 
     t2 = time.time()


### PR DESCRIPTION
I slightly improved the logging of `generate_stubs.py` to include the line of the invalid signatures as well as added a `--no-raise` argument to write the stubs file even if there are invalid signatures.